### PR TITLE
Prototype 2: ROI generation along a mock coastline vector

### DIFF
--- a/notebooks/CoastSeg Prototype 2 Generating Polygons along a Coastline (1).ipynb
+++ b/notebooks/CoastSeg Prototype 2 Generating Polygons along a Coastline (1).ipynb
@@ -1,0 +1,725 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "4e045903",
+   "metadata": {},
+   "source": [
+    "# CoastSeg Prototype: Generating Polygons along a CoastLine\n",
+    "- Author: Sharon Fitzpatrick\n",
+    "- Date: 1/13/2022\n",
+    "\n",
+    "## Description\n",
+    "This prototype is meant to show how you can generate polygons of various sizes along a coastline. The coastline in this prototype is only a geojson LineString for a small segment of the coast. Various widgets used to control the polygon generation are showcased, but none are implement with the exception of the size slider for the polygons.\n",
+    "\n",
+    "## Dependencies\n",
+    "1. ipyleaflet\n",
+    "2. ipywidgets\n",
+    "3. leafmap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "a17bfd04",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0d788a036ead47ad9a8d91d649f276f7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[36.46098029888645, -121.9725021429323], controls=(ZoomControl(options=['position', 'zoom_in_text',…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from ipyleaflet import DrawControl\n",
+    "import leafmap\n",
+    "from ipyleaflet import Map, Polygon\n",
+    "from ipywidgets import Layout\n",
+    "\n",
+    "# Center the map at the location where the coastvector is (swap the lat and lng)\n",
+    "shapes_list=[]\n",
+    "m = leafmap.Map(center=( 36.46098029888645, -121.9725021429323), zoom=13, layout=Layout(width='100%', height='100px'))\n",
+    "\n",
+    "draw_control = DrawControl()\n",
+    "draw_control.polygon = {\n",
+    "    \"shapeOptions\": {\n",
+    "        \"fillColor\": \"#a45df0\",\n",
+    "        \"color\": \"#6be5c3\",\n",
+    "        \"fillOpacity\": 0.4\n",
+    "    },\n",
+    "    \"drawError\": {\n",
+    "        \"color\": \"#dd253b\",\n",
+    "        \"message\": \"Ops!\"\n",
+    "    },\n",
+    "    \"allowIntersection\": False,\n",
+    "    \"transform\":True\n",
+    "}\n",
+    "\n",
+    "# Disable polyline, circle, and rectangle \n",
+    "draw_control.polyline = {}\n",
+    "draw_control.circlemarker = {}\n",
+    "draw_control.rectangle = {}\n",
+    "\n",
+    "# Each time a shape is drawn it is appended to the shapeslist which is used to create the bounding box\n",
+    "def handle_draw(target, action, geo_json):\n",
+    "    if draw_control.last_action == 'created':\n",
+    "        shapes_list.append( draw_control.last_draw['geometry'])\n",
+    "    print(\"\\nshapes_list: \",shapes_list)\n",
+    "\n",
+    "draw_control.on_draw(handle_draw)\n",
+    "m.add_control(draw_control)\n",
+    "\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a1b2f1d",
+   "metadata": {},
+   "source": [
+    "# Adding Widgets\n",
+    "------"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "65f821a5",
+   "metadata": {},
+   "source": [
+    "## Custom widget to show coordindates on hover\n",
+    "1. The first widget is completely optional. It allows the user to to the coordinates of their mouse on the map\n",
+    "\n",
+    "### Try it Out\n",
+    "- Hover your mouse on the map and watch how the coordinates below change"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "88a95c7e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "167a729537384e2b8096c36ce3023f38",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Label(value='')"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8f6fe728a35f46499888c6c4ccd8720d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(bottom=820493.0, center=[36.46098029888645, -121.9725021429323], controls=(ZoomControl(options=['position'…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from ipywidgets import Label\n",
+    "from ipyleaflet import Map\n",
+    "\n",
+    "\n",
+    "label = Label()\n",
+    "display(label)\n",
+    "\n",
+    "def handle_interaction(**kwargs):\n",
+    "    if kwargs.get('type') == 'mousemove':\n",
+    "        label.value = str(kwargs.get('coordinates'))\n",
+    "\n",
+    "m.on_interaction(handle_interaction)\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3077edf7",
+   "metadata": {},
+   "source": [
+    "## More Widgets\n",
+    "1. Location of super bounding box from geojson\n",
+    "    - A textarea that is used to hold the geojson of the bounding box\n",
+    "2. Size of the polygon ROI's\n",
+    "    - The size of the polygons generated along the coast line vector can be manipulated with a slider\n",
+    "3. Percent Overlap\n",
+    "    - The percentage of overlap between polygons generated along the coast line vector can be manipulated with a slider\n",
+    "4. Interval of ROI generation\n",
+    "    - The distance between polygons that are generated along the coast line vector"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f04aefa3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "04fb9457315645d5a77b630339724003",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "IntSlider(value=7, continuous_update=False, description='Interval for Polygon Generation(m):', layout=Layout(h…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c2c284c6827747e28acffa015b50029b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatSlider(value=5e-05, continuous_update=False, description='Polygon Size:', max=0.0002, min=5e-05, readout_…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cb936946cdb9447a9d15088ce2fff19e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatSlider(value=0.0, continuous_update=False, description='% Overlap:', max=0.5, step=0.01)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d794c66fc44e4e00a525c54195caa49d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Textarea(value=\"{'type':'Polygon', 'coordinates': [[[-121.929078, 36.459534], [-121.929078, 36.463013], [-121.…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8f6fe728a35f46499888c6c4ccd8720d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(bottom=820493.0, center=[36.46098029888645, -121.9725021429323], controls=(ZoomControl(options=['position'…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "from ipywidgets import  Layout\n",
+    "style = {'description_width': 'initial'}\n",
+    "\n",
+    "# Slider for the number of polygons to generate\n",
+    "# Not currently implement as of 1/3/2022\n",
+    "interval_slider=widgets.IntSlider(\n",
+    "    value=7,\n",
+    "    min=1,\n",
+    "    max=10,\n",
+    "    step=1,\n",
+    "    description='Interval for Polygon Generation(m):',\n",
+    "    disabled=False,\n",
+    "    continuous_update=False,\n",
+    "    orientation='horizontal',\n",
+    "    readout=True,\n",
+    "    readout_format='d',\n",
+    "    style=style,\n",
+    "    layout=Layout(width='45%', height='30px')\n",
+    ")\n",
+    "\n",
+    "# Slider for the size of the polygons to generate\n",
+    "size_slider=widgets.FloatSlider(\n",
+    "    value=0.00005,\n",
+    "    min=0.00005,\n",
+    "    max=0.0002,\n",
+    "    step=0.00001,\n",
+    "    description='Polygon Size:',\n",
+    "    disabled=False,\n",
+    "    continuous_update=False,\n",
+    "    orientation='horizontal',\n",
+    "    readout=True,\n",
+    "    readout_format='.5f',\n",
+    ")\n",
+    "\n",
+    "# Slider for the size of the polygons to generate\n",
+    "# Not currently implement as of 1/3/2022\n",
+    "overlap_percent_slider=widgets.FloatSlider(\n",
+    "    value=0.0,\n",
+    "    min=0.0,\n",
+    "    max=0.5,\n",
+    "    step=0.01,\n",
+    "    description='% Overlap:',\n",
+    "    disabled=False,\n",
+    "    continuous_update=False,\n",
+    "    orientation='horizontal',\n",
+    "    readout=True,\n",
+    "    readout_format='.2f',\n",
+    ")\n",
+    "\n",
+    "# Textarea to hold the geojson of the bounding box\n",
+    "# Not currently implement as of 1/3/2022\n",
+    "bounding_box_geojson=widgets.Textarea(\n",
+    "    value=\"{\\'type\\':\\'Polygon\\', \\'coordinates\\': [[[-121.929078, 36.459534], [-121.929078, 36.463013], [-121.926211, 36.463013], [-121.926211, 36.459534], [-121.929078, 36.459534]]]}\",\n",
+    "    placeholder='Type something',\n",
+    "    description='BBox GeoJson:',\n",
+    "    disabled=False,\n",
+    "    layout=Layout(width='50%', height='80px')\n",
+    "    , style=style\n",
+    ")\n",
+    "\n",
+    "\n",
+    "display(interval_slider)\n",
+    "display(size_slider)\n",
+    "display(overlap_percent_slider)\n",
+    "display(bounding_box_geojson)\n",
+    "\n",
+    "# Set the polygon's size to the slider's value\n",
+    "polygon_size= size_slider.value\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a881e864",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "polygon_size: 0.00015\n"
+     ]
+    }
+   ],
+   "source": [
+    "polygon_size= size_slider.value\n",
+    "print(f\"polygon_size: {polygon_size:.5f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8b81950",
+   "metadata": {},
+   "source": [
+    "## Convert ipyleaflet Polygon points to GeoJson\n",
+    "1. Ipyleaflet draws its shapes in lat,lng format and it must be converted to lng, lat for geojson.\n",
+    "2. In order to correctly draw a rectangle in geojson the order of the points matters as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "88b2d363",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def convert_to_geojson(upper_right_y, upper_right_x,upper_left_y, upper_left_x,lower_left_y,  lower_left_x,lower_right_y,lower_right_x):\n",
+    "    geojson_feature={}\n",
+    "    geojson_feature[\"type\"]=\"Feature\"\n",
+    "    geojson_feature[\"properties\"]={}\n",
+    "    geojson_feature[\"geometry\"]={}\n",
+    "    \n",
+    "    geojson_polygon={}\n",
+    "    geojson_polygon[\"type\"]=\"Polygon\"\n",
+    "    geojson_polygon[\"coordinates\"]=[]\n",
+    "#     The coordinates(which are 1,2 arrays) are nested within a parent array\n",
+    "    nested_array=[]\n",
+    "    nested_array.append([upper_right_x, upper_right_y])\n",
+    "    nested_array.append([upper_left_x, upper_left_y])\n",
+    "    nested_array.append([lower_left_x, lower_left_y])\n",
+    "    nested_array.append([lower_right_x, lower_right_y])\n",
+    "    #GeoJson rectangles have the first point repeated again as the last point\n",
+    "    nested_array.append([upper_right_x, upper_right_y])\n",
+    "\n",
+    "    geojson_polygon[\"coordinates\"].append(nested_array)\n",
+    "    \n",
+    "    geojson_feature[\"geometry\"]=geojson_polygon\n",
+    "#     new_polygon_list.append(new_polygon)\n",
+    "#     print(geojson_feature)\n",
+    "    return geojson_feature"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77ccdac4",
+   "metadata": {},
+   "source": [
+    "## Generating Polygons Along a Vector\n",
+    "1. Import the geojson, LineString, that represents the coastline  vector.\n",
+    "2. Using the size slider from earlier the size of each polygon is chosen\n",
+    "3. The points of the each polygon are generated based on the size provided and their location along the LineString\n",
+    "4. Once all the polygons are generated they are converted to geojson for future use with geopandas.\n",
+    "5. To display the polygons on the map simply add each polygon as layer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "fc335387",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "04fb9457315645d5a77b630339724003",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "IntSlider(value=7, continuous_update=False, description='Interval for Polygon Generation(m):', layout=Layout(h…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c2c284c6827747e28acffa015b50029b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatSlider(value=0.00015, continuous_update=False, description='Polygon Size:', max=0.0002, min=5e-05, readou…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cb936946cdb9447a9d15088ce2fff19e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatSlider(value=0.26, continuous_update=False, description='% Overlap:', max=0.5, step=0.01)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d794c66fc44e4e00a525c54195caa49d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Textarea(value=\"{'type':'Polygon', 'coordinates': [[[-121.929078, 36.459534], [-121.929078, 36.463013], [-121.…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0d788a036ead47ad9a8d91d649f276f7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(bottom=820493.0, center=[36.46098029888645, -121.9725021429323], controls=(ZoomControl(options=['position'…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# TEMPORARY: hard coded vector (linestring) that holds the coast vector\n",
+    "# This would be replaced by the real coast vector\n",
+    "coast_vector_geojson={\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"type\":\"LineString\",\"coordinates\":[[-121.92830801010132,36.46290061292468],[-121.92837238311768,36.46217580890998],[-121.92805051803589,36.46177888955466],[-121.92787885665892,36.46224483815569],[-121.92768573760988,36.46186517654388],[-121.92764282226564,36.461520028010895],[-121.92755699157713,36.46115762039776],[-121.92755699157713,36.46103681748364],[-121.92721366882324,36.46103681748364],[-121.92702054977417,36.46103681748364],[-121.9269347190857,36.461019559909126],[-121.92687034606932,36.46088149917467],[-121.92676305770874,36.460570861623395],[-121.92676305770874,36.46034651150687],[-121.92674160003662,36.4601911918152],[-121.92663431167601,36.460070387395476],[-121.9269347190857,36.45984603583096],[-121.92667722702028,36.45974248873611]]}}]}\n",
+    "m.add_geojson(coast_vector_geojson, layer_name=\"coast line\")\n",
+    "m\n",
+    "# Get only the coordinates from the geojson these will be used to create the polygons and geojson\n",
+    "vector_points=coast_vector_geojson['features'][0]['geometry']['coordinates']\n",
+    "vector_points\n",
+    "\n",
+    "from ipyleaflet import Map, Polygon\n",
+    "size=polygon_size\n",
+    "new_polygon_list=[]\n",
+    "geojson_polygons={\"type\": \"FeatureCollection\",\"features\":[]}\n",
+    "\n",
+    "# Create a rectangle at each point on the line\n",
+    "# Swap the x and y for each point because ipyleaflet swaps them for draw methods\n",
+    "for point in vector_points:\n",
+    "    upper_right_x=point[0]-(size/2)\n",
+    "    upper_right_y=point[1]-(size/2)\n",
+    "    upper_left_x=point[0]+(size/2)\n",
+    "    upper_left_y=point[1]-(size/2)\n",
+    "    lower_left_x=point[0]+(size/2)\n",
+    "    lower_left_y=point[1]+(size/2)\n",
+    "    lower_right_x=point[0]-(size/2)\n",
+    "    lower_right_y=point[1]+(size/2)\n",
+    "    \n",
+    "    #NOTE: the x and y are swapped because ipyleaflet swaps the latitude and the longtitude for polygons\n",
+    "    new_polygon=Polygon(\n",
+    "    locations=[(upper_right_y, upper_right_x),(upper_left_y, upper_left_x),( lower_left_y,  lower_left_x),(lower_right_y,lower_right_x)],\n",
+    "    color=\"pink\",\n",
+    "    fill_color=\"pink\")\n",
+    "    \n",
+    "    #Append the polygon we created to the list of polygons to draw onto the map\n",
+    "    new_polygon_list.append(new_polygon)\n",
+    "    \n",
+    "    #Convert each set of points to geojson (DONT swap x and y this time)\n",
+    "    geojson_polygon=convert_to_geojson(upper_right_y, upper_right_x,upper_left_y, upper_left_x,lower_left_y,  lower_left_x,lower_right_y,lower_right_x)\n",
+    "    geojson_polygons[\"features\"].append(geojson_polygon)\n",
+    "\n",
+    "\n",
+    "# Draw all the polygons along the coast vector to the map  \n",
+    "for item in new_polygon_list:\n",
+    "    m.add_layer(item);\n",
+    "\n",
+    "display(interval_slider)\n",
+    "display(size_slider)\n",
+    "display(overlap_percent_slider)\n",
+    "display(bounding_box_geojson)\n",
+    "\n",
+    "polygon_size= size_slider.value\n",
+    "m.on_interaction(handle_interaction)\n",
+    "m\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "3acd82da",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'type': 'FeatureCollection',\n",
+       " 'features': [{'type': 'Feature',\n",
+       "   'properties': {},\n",
+       "   'geometry': {'type': 'Polygon',\n",
+       "    'coordinates': [[[-121.92838301010131, 36.462825612924675],\n",
+       "      [-121.92823301010132, 36.462825612924675],\n",
+       "      [-121.92823301010132, 36.46297561292468],\n",
+       "      [-121.92838301010131, 36.46297561292468],\n",
+       "      [-121.92838301010131, 36.462825612924675]]]}},\n",
+       "  {'type': 'Feature',\n",
+       "   'properties': {},\n",
+       "   'geometry': {'type': 'Polygon',\n",
+       "    'coordinates': [[[-121.92844738311767, 36.46210080890998],\n",
+       "      [-121.92829738311768, 36.46210080890998],\n",
+       "      [-121.92829738311768, 36.462250808909985],\n",
+       "      [-121.92844738311767, 36.462250808909985],\n",
+       "      [-121.92844738311767, 36.46210080890998]]]}},\n",
+       "  {'type': 'Feature',\n",
+       "   'properties': {},\n",
+       "   'geometry': {'type': 'Polygon',\n",
+       "    'coordinates': [[[-121.92812551803588, 36.461703889554656],\n",
+       "      [-121.9279755180359, 36.461703889554656],\n",
+       "      [-121.9279755180359, 36.46185388955466],\n",
+       "      [-121.92812551803588, 36.46185388955466],\n",
+       "      [-121.92812551803588, 36.461703889554656]]]}},\n",
+       "  {'type': 'Feature',\n",
+       "   'properties': {},\n",
+       "   'geometry': {'type': 'Polygon',\n",
+       "    'coordinates': [[[-121.92795385665892, 36.46216983815569],\n",
+       "      [-121.92780385665893, 36.46216983815569],\n",
+       "      [-121.92780385665893, 36.46231983815569],\n",
+       "      [-121.92795385665892, 36.46231983815569],\n",
+       "      [-121.92795385665892, 36.46216983815569]]]}},\n",
+       "  {'type': 'Feature',\n",
+       "   'properties': {},\n",
+       "   'geometry': {'type': 'Polygon',\n",
+       "    'coordinates': [[[-121.92776073760987, 36.46179017654388],\n",
+       "      [-121.92761073760988, 36.46179017654388],\n",
+       "      [-121.92761073760988, 36.461940176543884],\n",
+       "      [-121.92776073760987, 36.461940176543884],\n",
+       "      [-121.92776073760987, 36.46179017654388]]]}},\n",
+       "  {'type': 'Feature',\n",
+       "   'properties': {},\n",
+       "   'geometry': {'type': 'Polygon',\n",
+       "    'coordinates': [[[-121.92771782226563, 36.46144502801089],\n",
+       "      [-121.92756782226564, 36.46144502801089],\n",
+       "      [-121.92756782226564, 36.4615950280109],\n",
+       "      [-121.92771782226563, 36.4615950280109],\n",
+       "      [-121.92771782226563, 36.46144502801089]]]}},\n",
+       "  {'type': 'Feature',\n",
+       "   'properties': {},\n",
+       "   'geometry': {'type': 'Polygon',\n",
+       "    'coordinates': [[[-121.92763199157713, 36.46108262039776],\n",
+       "      [-121.92748199157714, 36.46108262039776],\n",
+       "      [-121.92748199157714, 36.461232620397766],\n",
+       "      [-121.92763199157713, 36.461232620397766],\n",
+       "      [-121.92763199157713, 36.46108262039776]]]}},\n",
+       "  {'type': 'Feature',\n",
+       "   'properties': {},\n",
+       "   'geometry': {'type': 'Polygon',\n",
+       "    'coordinates': [[[-121.92763199157713, 36.460961817483636],\n",
+       "      [-121.92748199157714, 36.460961817483636],\n",
+       "      [-121.92748199157714, 36.46111181748364],\n",
+       "      [-121.92763199157713, 36.46111181748364],\n",
+       "      [-121.92763199157713, 36.460961817483636]]]}},\n",
+       "  {'type': 'Feature',\n",
+       "   'properties': {},\n",
+       "   'geometry': {'type': 'Polygon',\n",
+       "    'coordinates': [[[-121.92728866882324, 36.460961817483636],\n",
+       "      [-121.92713866882325, 36.460961817483636],\n",
+       "      [-121.92713866882325, 36.46111181748364],\n",
+       "      [-121.92728866882324, 36.46111181748364],\n",
+       "      [-121.92728866882324, 36.460961817483636]]]}},\n",
+       "  {'type': 'Feature',\n",
+       "   'properties': {},\n",
+       "   'geometry': {'type': 'Polygon',\n",
+       "    'coordinates': [[[-121.92709554977417, 36.460961817483636],\n",
+       "      [-121.92694554977417, 36.460961817483636],\n",
+       "      [-121.92694554977417, 36.46111181748364],\n",
+       "      [-121.92709554977417, 36.46111181748364],\n",
+       "      [-121.92709554977417, 36.460961817483636]]]}},\n",
+       "  {'type': 'Feature',\n",
+       "   'properties': {},\n",
+       "   'geometry': {'type': 'Polygon',\n",
+       "    'coordinates': [[[-121.92700971908569, 36.46094455990912],\n",
+       "      [-121.9268597190857, 36.46094455990912],\n",
+       "      [-121.9268597190857, 36.46109455990913],\n",
+       "      [-121.92700971908569, 36.46109455990913],\n",
+       "      [-121.92700971908569, 36.46094455990912]]]}},\n",
+       "  {'type': 'Feature',\n",
+       "   'properties': {},\n",
+       "   'geometry': {'type': 'Polygon',\n",
+       "    'coordinates': [[[-121.92694534606932, 36.460806499174666],\n",
+       "      [-121.92679534606933, 36.460806499174666],\n",
+       "      [-121.92679534606933, 36.46095649917467],\n",
+       "      [-121.92694534606932, 36.46095649917467],\n",
+       "      [-121.92694534606932, 36.460806499174666]]]}},\n",
+       "  {'type': 'Feature',\n",
+       "   'properties': {},\n",
+       "   'geometry': {'type': 'Polygon',\n",
+       "    'coordinates': [[[-121.92683805770874, 36.46049586162339],\n",
+       "      [-121.92668805770874, 36.46049586162339],\n",
+       "      [-121.92668805770874, 36.4606458616234],\n",
+       "      [-121.92683805770874, 36.4606458616234],\n",
+       "      [-121.92683805770874, 36.46049586162339]]]}},\n",
+       "  {'type': 'Feature',\n",
+       "   'properties': {},\n",
+       "   'geometry': {'type': 'Polygon',\n",
+       "    'coordinates': [[[-121.92683805770874, 36.46027151150687],\n",
+       "      [-121.92668805770874, 36.46027151150687],\n",
+       "      [-121.92668805770874, 36.46042151150687],\n",
+       "      [-121.92683805770874, 36.46042151150687],\n",
+       "      [-121.92683805770874, 36.46027151150687]]]}},\n",
+       "  {'type': 'Feature',\n",
+       "   'properties': {},\n",
+       "   'geometry': {'type': 'Polygon',\n",
+       "    'coordinates': [[[-121.92681660003662, 36.460116191815196],\n",
+       "      [-121.92666660003663, 36.460116191815196],\n",
+       "      [-121.92666660003663, 36.4602661918152],\n",
+       "      [-121.92681660003662, 36.4602661918152],\n",
+       "      [-121.92681660003662, 36.460116191815196]]]}},\n",
+       "  {'type': 'Feature',\n",
+       "   'properties': {},\n",
+       "   'geometry': {'type': 'Polygon',\n",
+       "    'coordinates': [[[-121.926709311676, 36.45999538739547],\n",
+       "      [-121.92655931167602, 36.45999538739547],\n",
+       "      [-121.92655931167602, 36.46014538739548],\n",
+       "      [-121.926709311676, 36.46014538739548],\n",
+       "      [-121.926709311676, 36.45999538739547]]]}},\n",
+       "  {'type': 'Feature',\n",
+       "   'properties': {},\n",
+       "   'geometry': {'type': 'Polygon',\n",
+       "    'coordinates': [[[-121.92700971908569, 36.459771035830954],\n",
+       "      [-121.9268597190857, 36.459771035830954],\n",
+       "      [-121.9268597190857, 36.45992103583096],\n",
+       "      [-121.92700971908569, 36.45992103583096],\n",
+       "      [-121.92700971908569, 36.459771035830954]]]}},\n",
+       "  {'type': 'Feature',\n",
+       "   'properties': {},\n",
+       "   'geometry': {'type': 'Polygon',\n",
+       "    'coordinates': [[[-121.92675222702027, 36.45966748873611],\n",
+       "      [-121.92660222702028, 36.45966748873611],\n",
+       "      [-121.92660222702028, 36.459817488736114],\n",
+       "      [-121.92675222702027, 36.459817488736114],\n",
+       "      [-121.92675222702027, 36.45966748873611]]]}}]}"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Print the geojson of the polygons generated by the application along the coast line\n",
+    "geojson_polygons"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28eed5b1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/geojson_extracter_v1.ipynb
+++ b/notebooks/geojson_extracter_v1.ipynb
@@ -1,0 +1,242 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f15b9fa3",
+   "metadata": {},
+   "source": [
+    "## Interactive Drawable Map with CoastSat's Geojson\n",
+    "- [CoastSat Github](https://github.com/kvos/CoastSat) \n",
+    "- Website where geojson was collected [CoastSat Website](http://coastsat.wrl.unsw.edu.au/)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d06430dd",
+   "metadata": {},
+   "source": [
+    "## Optional Code to Install json, ipyleaflet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9a1a5df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# pip install json\n",
+    "# pip install ipyleaflet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9ee7f39f",
+   "metadata": {},
+   "source": [
+    "## Add Clustering to Points\n",
+    "1. Import all the necessary libraries to draw the map\n",
+    "2. Open CoastSat's geojson\n",
+    "3. Create a zoomed out Map\n",
+    "4. Load in the geojson with the GeoJSON function\n",
+    "    - choose the geojson to load in\n",
+    "    - style the geojson\n",
+    "    - add a hover style interaction\n",
+    "5. Make markers from the geojson data\n",
+    "6. Transform the markers into a cluster (for better loading + visibility ) and add them as a layer to the map called \"CoastSat Shoreline Data\"\n",
+    "7. Add layer selection control\n",
+    "8. Add a scale control\n",
+    "9. Display the map\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "006f53d5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9770856dc88a401eb7b06c163d0e9e6e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[50.6252978589571, 0.34580993652344], controls=(ZoomControl(options=['position', 'zoom_in_text', 'z…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import json\n",
+    "import random\n",
+    "\n",
+    "from ipyleaflet import Map, GeoJSON, Icon, Marker, MarkerCluster, LayersControl, basemap_to_tiles ,basemaps\n",
+    "\n",
+    "# Name of the geojson: metadata_Pacific_CoastSat.geojson\n",
+    "with open(r'C:\\Users\\Sharon\\Desktop\\metadata_Pacific_CoastSat.geojson', 'r') as f:\n",
+    "    data = json.load(f)\n",
+    "\n",
+    "m = Map(center=(50.6252978589571, 0.34580993652344), zoom=1)\n",
+    "\n",
+    "# Optional Code if you want to have a different color for each geojson feature\n",
+    "def random_color(feature):\n",
+    "    return {\n",
+    "        'color': 'black',\n",
+    "        'fillColor': random.choice(['red', 'yellow', 'green', 'orange']),\n",
+    "    }\n",
+    "\n",
+    "geo_json = GeoJSON(\n",
+    "    data=data,\n",
+    "    style={\n",
+    "        'opacity': 1, 'dashArray': '8', 'fillOpacity': 0.1, 'weight': 1\n",
+    "    },\n",
+    "    hover_style={\n",
+    "        'color': 'white', 'dashArray': '0', 'fillOpacity': 0.2\n",
+    "    },\n",
+    "    style_callback=random_color     #This calls the random_color function to style each geojson feature\n",
+    ")\n",
+    "\n",
+    "# This turns all of the marks into maps to make them easier to view\n",
+    "markers = ()\n",
+    "features = data['features']\n",
+    "# Map each locations latitde and longtitde to a marker then add it to the cluster as a tuple\n",
+    "for i in range(len(features)):\n",
+    "    location=(features[i]['geometry']['coordinates'][1],features[i]['geometry']['coordinates'][0])\n",
+    "    marker = Marker(location=location)\n",
+    "    markers = markers + (marker,)\n",
+    "\n",
+    "m.add_layer(MarkerCluster(name = \"CoastSat Shoreline Data\",markers = markers,))\n",
+    "\n",
+    "# Add another layer\n",
+    "dark_matter_layer = basemap_to_tiles(basemaps.Stamen.Terrain)\n",
+    "m.add_layer(dark_matter_layer)\n",
+    "\n",
+    "\n",
+    "# Add a way to control which layers are displayed\n",
+    "m.add_control(LayersControl())\n",
+    "\n",
+    "# Add a scale to the map\n",
+    "from ipyleaflet import ScaleControl\n",
+    "m.add_control(ScaleControl(position='bottomleft'))\n",
+    "\n",
+    "# Display the map\n",
+    "m\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3384ed9f",
+   "metadata": {},
+   "source": [
+    "## Add Polygon Draw Control\n",
+    "- Made it so the user can only draw polygons\n",
+    "- Each polygon the user draws is add to the shape_list\n",
+    "- IDEA: use the shape_list to provide data to CoastSat\n",
+    "- WARNING: if you run this cell twice in jupyter notebook it was a weird effect of adding an extra polygon button to the drawing control"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6e15542a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bbd9fe98085946618151bcdfef2723f0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[50.6252978589571, 0.34580993652344], controls=(ZoomControl(options=['position', 'zoom_in_text', 'z…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "shapes_list:  [{'type': 'Polygon', 'coordinates': [[[-188.659363, 51.495065], [-191.216476, 18.398144], [-127.289512, 31.129926], [-188.659363, 51.495065]]]}]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from ipyleaflet import DrawControl\n",
+    "\n",
+    "shapes_list=[]\n",
+    "\n",
+    "draw_control = DrawControl()\n",
+    "draw_control.polygon = {\n",
+    "    \"shapeOptions\": {\n",
+    "        \"fillColor\": \"#6be5c3\",\n",
+    "        \"color\": \"#6be5c3\",\n",
+    "        \"fillOpacity\": 0.4\n",
+    "    },\n",
+    "    \"drawError\": {\n",
+    "        \"color\": \"#dd253b\",\n",
+    "        \"message\": \"Ops!\"\n",
+    "    },\n",
+    "    \"allowIntersection\": False,\n",
+    "    \"transform\":True\n",
+    "}\n",
+    "\n",
+    "# Disable polyline, circle, and rectangle \n",
+    "draw_control.polyline = {}\n",
+    "draw_control.circlemarker = {}\n",
+    "draw_control.rectangle = {}\n",
+    "\n",
+    "def handle_draw(target, action, geo_json):\n",
+    "    if draw_control.last_action == 'created':\n",
+    "        shapes_list.append( draw_control.last_draw['geometry'])\n",
+    "    print(\"\\nshapes_list: \",shapes_list)\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "draw_control.on_draw(handle_draw)\n",
+    "m.add_control(draw_control)\n",
+    "\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b53a39d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(shapes_list)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
# Prototype 2: ROI generation along a mock coastline vector

This jupyter notebook showcases how ROIs can be generated along a mock coastline vector as well as how to use ipywidgets to create controls for ROI generation by controlling size, overlap, etc.  Additionally, the data from the generated ROIs can be converted to geojson for further use with geopandas.


![prototype_v2_tools_polygons](https://user-images.githubusercontent.com/61564689/148111739-ba1c9b70-dfb4-4063-a357-2f68298e4226.png)

NOTE: The coastline vector used in this prototype is a geojson LineString for a small segment of the coast. This will not be used in the final version.

NOTE2: As indicated in the notebook the controls are not all implemented yet, only polygon size has been implemented so far.
