### PR TITLE
Added area as a pip dependency

### DIFF
--- a/install/coastseg.yml
+++ b/install/coastseg.yml
@@ -4,28 +4,31 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-- python=3.7
-- earthengine-api
-- google-api-python-client
-- gdal
-- rasterio
-- pandas
-- geopandas
-- numpy
-- matplotlib
-- pillow
-- pytz
-- scikit-image
-- scikit-learn
-- shapely
-- scipy
-- astropy
-- jupyter
-- ipython
-- pyproj
-- cartopy
-- pyproj
-- simplekml
-- pip
-- pip:
-   - localtileserver
+  - python=3.7
+  - earthengine-api
+  - google-api-python-client
+  - gdal
+  - rasterio
+  - pandas
+  - geopandas
+  - numpy
+  - matplotlib
+  - pillow
+  - pytz
+  - scikit-image
+  - scikit-learn
+  - shapely
+  - scipy
+  - astropy
+  - jupyter
+  - ipython
+  - pyproj
+  - cartopy
+  - pyproj
+  - simplekml
+  - pip
+  - ipyleaflet
+  - leafmap
+  - pip:
+      - localtileserver
+      - area


### PR DESCRIPTION
I added **area** as a dependency which is needed for prototype 6 to function properly.

The only file modified in this PR is the coastseg.yml where I added 
```
 - pip:
      - localtileserver
      - area      #new code
```

## PYPI
https://pypi.org/project/area/
## GitHub
https://github.com/scisco/area