### PR TITLE
Coastline vector branch

### DIFF
--- a/install/coastseg.yml
+++ b/install/coastseg.yml
@@ -4,28 +4,31 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-- python=3.7
-- earthengine-api
-- google-api-python-client
-- gdal
-- rasterio
-- pandas
-- geopandas
-- numpy
-- matplotlib
-- pillow
-- pytz
-- scikit-image
-- scikit-learn
-- shapely
-- scipy
-- astropy
-- jupyter
-- ipython
-- pyproj
-- cartopy
-- pyproj
-- simplekml
-- pip
-- pip:
-   - localtileserver
+  - python=3.7
+  - earthengine-api
+  - google-api-python-client
+  - gdal
+  - rasterio
+  - pandas
+  - geopandas
+  - numpy
+  - matplotlib
+  - pillow
+  - pytz
+  - scikit-image
+  - scikit-learn
+  - shapely
+  - scipy
+  - astropy
+  - jupyter
+  - ipython
+  - pyproj
+  - cartopy
+  - pyproj
+  - simplekml
+  - pip
+  - ipyleaflet
+  - leafmap
+  - pip:
+      - localtileserver
+      - area


### PR DESCRIPTION
This PR added the Stanford coastline vector geojson to CoastSeg. This geojson is necessary for prototype 6 to function properly

This PR builds on the previously submitted PR #27 where "area" was added as a dependency. 
