### PR TITLE
Prototype6 coastsat roi download

### DIFF
--- a/notebooks/Prototype 6_CoastSat_download_ROIs.ipynb
+++ b/notebooks/Prototype 6_CoastSat_download_ROIs.ipynb
@@ -1,0 +1,20067 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "48fabbdc-840d-4b9d-a3f0-814e12769264",
+   "metadata": {},
+   "source": [
+    "# Prototype 6: Using CoastSat to download ROIs\n",
+    "- Author: Sharon Fitzpatrick\n",
+    "- Date: 1/18/2022\n",
+    "\n",
+    "## Description\n",
+    "This prototype showcases an interactive map where users can click on various ROIs to download their data with CoastSat.\n",
+    "\n",
+    "## The Workflow\n",
+    "1. The user draws a bounding box\n",
+    "2. The user runs the code to clip the coastline geojson to the bounding box\n",
+    "3. The user runs the code to add the coastline within the bounding box to the map. (The coastline will be in yellow)\n",
+    "4. The user runs the code to to generate polygons along the portion of the coastline vector within the bounding box\n",
+    "5. The user runs the code to plot the polygons and associated markers to the map.\n",
+    "6. The user selects at least one ROI for download with CoastSat by clicking on any ROI on the map\n",
+    "7. The user runs the code to download the geojson for the ROIs they selected\n",
+    "8. The user runs the code to download all the data using CoastSat for the ROIs they selected."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5322ae5-19fb-4f49-b34c-e3af79db5c00",
+   "metadata": {},
+   "source": [
+    "# Get the Bounding Box Geojson\n",
+    "## Directions\n",
+    "1. Use the square drawing button to draw a bounding box somewhere along the coast\n",
+    "\n",
+    "## !! Warning !!\n",
+    "- If the bounding box drawn is too small or too large you will need to re-run the code to generate the map again."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "7e3ff0e2-8b5e-4ed6-b1e8-0c0363ab66eb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipywidgets import Layout\n",
+    "map_settings={\n",
+    "\"center_point\":( 36.100206171202295, -75.71024865851251),\n",
+    "\"zoom\":13,\n",
+    " \"draw_control\":False,\n",
+    " \"measure_control\":False, \n",
+    " \"fullscreen_control\":False, \n",
+    " \"attribution_control\":True,\n",
+    " \"Layout\":Layout(width='100%', height='100px')\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "bd510baf-94f6-4d67-ab8d-553ebf6a3290",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6e36cf6ae2974ca2a8db27e1cb111e3e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[36.100206171202295, -75.71024865851251], controls=(ZoomControl(options=['position', 'zoom_in_text'…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from ipyleaflet import DrawControl, Map, GeoJSON, Polygon\n",
+    "import leafmap\n",
+    "from shapely.geometry import shape, LineString, Point\n",
+    "from area import area\n",
+    "import geopandas as gpd\n",
+    "import json\n",
+    "import os\n",
+    "from shapely.ops import unary_union\n",
+    "import numpy as np\n",
+    "from geojson import Point, Feature, FeatureCollection, dump\n",
+    "\n",
+    "\n",
+    "# Empty list to hold all the polygons drawn by the user\n",
+    "shapes_list=[]\n",
+    "\n",
+    "# Disable polyline, circle, and rectangle \n",
+    "m = leafmap.Map(draw_control=map_settings[\"draw_control\"],\n",
+    "                measure_control=map_settings[\"measure_control\"],\n",
+    "                fullscreen_control=map_settings[\"fullscreen_control\"],\n",
+    "                attribution_control=map_settings[\"attribution_control\"],\n",
+    "                center=map_settings[\"center_point\"],\n",
+    "                zoom=map_settings[\"zoom\"],\n",
+    "                layout=map_settings[\"Layout\"])\n",
+    "\n",
+    "draw_control = DrawControl()\n",
+    "\n",
+    "draw_control.polyline = {}\n",
+    "draw_control.circlemarker = {}\n",
+    "# Custom styles for polygons and rectangles\n",
+    "draw_control.polygon = {\n",
+    "    \"shapeOptions\": {\n",
+    "        \"fillColor\": \"green\",\n",
+    "        \"color\": \"green\",\n",
+    "        \"fillOpacity\": 0.2,\n",
+    "        \"Opacity\": 0.2\n",
+    "    },\n",
+    "    \"drawError\": {\n",
+    "        \"color\": \"#dd253b\",\n",
+    "        \"message\": \"Ops!\"\n",
+    "    },\n",
+    "    \"allowIntersection\": False,\n",
+    "    \"transform\":True\n",
+    "}\n",
+    "\n",
+    "draw_control = DrawControl()\n",
+    "draw_control.rectangle = {\n",
+    "    \"shapeOptions\": {\n",
+    "        \"fillColor\": \"green\",\n",
+    "        \"color\": \"green\",\n",
+    "        \"fillOpacity\": 0.1,\n",
+    "        \"Opacity\": 0.1\n",
+    "    },\n",
+    "    \"drawError\": {\n",
+    "        \"color\": \"#dd253b\",\n",
+    "        \"message\": \"Ops!\"\n",
+    "    },\n",
+    "    \"allowIntersection\": False,\n",
+    "    \"transform\":True\n",
+    "}\n",
+    "\n",
+    "# Each time a polygon is drawn it is appended to the shapeslist which is used to create the bounding box\n",
+    "def handle_draw(target, action, geo_json):\n",
+    "    if draw_control.last_action == 'created'and draw_control.last_draw['geometry']['type']=='Polygon' :\n",
+    "        shapes_list.append( draw_control.last_draw['geometry'])\n",
+    "    if draw_control.last_action == 'deleted':\n",
+    "        label1.value=str(f\"{draw_control.last_draw['geometry']['type']}  {draw_control.last_action}\")\n",
+    "        shapes_list.pop()\n",
+    "\n",
+    "draw_control.on_draw(handle_draw)\n",
+    "m.add_control(draw_control)\n",
+    "\n",
+    "m\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8fc61b15-6703-4680-8d85-d94f6ccd3a74",
+   "metadata": {},
+   "source": [
+    "### Select the name of the file that will hold the geojson for all the ROIs generated"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "920d70a8-b57b-405c-b1bb-d475fc8aa9fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filename = \"roi.geojson\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25039629-418f-4e4b-b09f-835a60db91ee",
+   "metadata": {},
+   "source": [
+    "# Check the size of the Bounding Box \n",
+    "1. Obtain the area of the bounding box using **calculate_area_bbox**\n",
+    "3. Check if its a valid size suing **check_bbox_size**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4040d975-6f67-419b-8f44-9aff73c76ff4",
+   "metadata": {},
+   "source": [
+    "### Custom Exceptions for Invalid BBox size\n",
+    "1. BboxTooLargeError\n",
+    "2. BboxTooSmallError"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ac07e659-421a-41d1-96e8-b786e2fb77a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class BboxTooLargeError(Exception):\n",
+    "    \"\"\"BboxTooLargeError: raised when bounding box is larger than MAX_BBOX_SIZE\n",
+    "    Args:\n",
+    "        Exception: Inherits from the base exception class\n",
+    "    \"\"\"\n",
+    "    def __init__(self, msg=\"The bounding box was too large.\"):\n",
+    "        self.msg=msg\n",
+    "        super().__init__(self.msg)\n",
+    "    def __str__(self):\n",
+    "        return (f\"{self.msg}\")\n",
+    "    \n",
+    "class BboxTooSmallError(Exception):\n",
+    "    \"\"\"BboxTooLargeError: raised when bounding box is smaller than MIN_BBOX_SIZE\n",
+    "    Args:\n",
+    "        Exception: Inherits from the base exception class\n",
+    "    \"\"\"\n",
+    "    def __init__(self, msg=\"The bounding box was too small.\"):\n",
+    "        self.msg=msg\n",
+    "        super().__init__(self.msg)\n",
+    "    def __str__(self):\n",
+    "        return (f\"{self.msg}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "76c56548-04bb-4d71-9dc4-ca386a9890c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def calculate_area_bbox(bbox):\n",
+    "    bbox_area=round(area(bbox),2)\n",
+    "    print(f\"Area: {bbox_area} meters squared\")\n",
+    "    return bbox_area"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e7cf65b-555e-43c3-870a-4f736b506c52",
+   "metadata": {},
+   "source": [
+    "## Function erase_bbox\n",
+    "- Clears any data associated with invalid bbox\n",
+    "- NOTE: If the bbox size is invalid re-run the code to re-create the map\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "497c8ef5-1eef-4a30-8516-0458e9aa54b6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def erase_bbox(draw_control : 'ipyleaflet.leaflet.DrawControl',shapeslist:list)-> list:\n",
+    "    \"\"\"Erases bounding box from map and deletes the contents of the shapeslist\"\"\"\n",
+    "    draw_control.clear()\n",
+    "    shapeslist=[]\n",
+    "    return shapeslist"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ec959ce-d2e5-4918-87fc-5172b5a03eaa",
+   "metadata": {},
+   "source": [
+    "## Check if the bounding box size is allowed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "8dbb679d-6e97-4a54-89f2-134471979991",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def check_bbox_size(bbox_area:float,shapes_list:list):\n",
+    "    \"\"\"\"Raises an exception and clears the map if the size of the bounding box is too large or small.\"\"\"\n",
+    "    # CONSTANT SIZE VARIABLES\n",
+    "    # UNITS = Sq. Meters\n",
+    "    MAX_BBOX_SIZE=1000000000\n",
+    "    MIN_BBOX_SIZE=300\n",
+    "    # Check if the size is greater than MAX_BBOX_SIZE\n",
+    "    if bbox_area > MAX_BBOX_SIZE:\n",
+    "        shapes_list=erase_bbox(draw_control,shapes_list)\n",
+    "        raise BboxTooLargeError\n",
+    "    # Check if size smaller than MIN_BBOX_SIZE\n",
+    "    elif bbox_area < MIN_BBOX_SIZE:\n",
+    "        shapes_list=erase_bbox(draw_control,shapes_list)\n",
+    "        raise BboxTooSmallError"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "29b7a10a-901f-4c1d-9524-4ba74933dce9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Area: 24088522.35 meters squared\n"
+     ]
+    }
+   ],
+   "source": [
+    "if not shapes_list == []:\n",
+    "    last_index=len(shapes_list)-1\n",
+    "#     The last index in the shapes_list was the last shape drawn\n",
+    "    bbox_area=calculate_area_bbox(shapes_list[last_index])\n",
+    "    check_bbox_size(bbox_area,shapes_list)\n",
+    "else:\n",
+    "     print(\"ERROR.\\nYou must draw a bounding box somewhere on the coast first.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd079f17-d8d1-4db0-a09e-ebd30960f32a",
+   "metadata": {},
+   "source": [
+    "# Clip the Bounding Box and Vector\n",
+    "---\n",
+    "1. Convert the bounding box to a geopandas geodataframe using **create_geodataframe_from_bbox**\n",
+    "2. Print the bounds of the geodataframe"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "5a736c10-6704-40a2-9787-aff7a9ca2756",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_geodataframe_from_bbox(shapes_list:list)->\"geopandas.geodataframe.GeoDataFrame\":\n",
+    "    if not shapes_list == []:\n",
+    "        geom = [shape(i) for i in shapes_list]\n",
+    "        geojson_bbox=gpd.GeoDataFrame({'geometry':geom})\n",
+    "        geojson_bbox.crs='EPSG:4326'\n",
+    "        geojson_bbox.plot()\n",
+    "        return geojson_bbox\n",
+    "    else:\n",
+    "        print(\"ERROR.\\nYou must draw a bounding box somewhere on the coast first.\")\n",
+    "        return None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "8f51f7f8-a44c-4729-bb86-94441a418b71",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Geojson bounds\n",
+      "        minx       miny       maxx       maxy\n",
+      "0 -75.772945  36.091104 -75.704786  36.126405\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYcAAAD2CAYAAAA9F0uuAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAXlUlEQVR4nO3df6xf9X3f8ecL/wBvSgStL52J49pWbLSYOWbYLtXqbHUhsWgbp42ygsLkikgWjPDPVBZYGm1MYnJptq4SrQhiLkTL8KyAHUKg1Mn4MSZiY4rt2MRuDEmVK6NcY8YiN+n1MO/98T1Wvr3ne7nfr++9/pE9H9JX95z3OZ9z3sey78vnx/f7TVUhSVK3C852A5Kkc4/hIElqMRwkSS2GgySpxXCQJLUYDpKklplnu4GpMHfu3Fq4cOHZbkOSzisvvfTSG1U11GvZz0Q4LFy4kN27d5/tNiTpvJLkr8db5mUlSVKL4SBJajEcJEkthoMkqcVwkCS1GA6SpBbDQZLUYjhIklp+Jt4EN1kL7/j62W5Bkk7L9zf9+rRs1zMHSVKL4SBJajEcJEktE4ZDkouS7EqyN8mBJHd1LbstyaGmfs844zcnGUmyf0z9D5McTLIvybYkFzf1hUl+kmRP87pvkscoSRpQPzekR4G1VXU8ySzg+SRPAnOA9cDyqhpNcuk44x8E7gW+NKa+A7izqt5O8gfAncBnm2WvVtWKwQ5FkjRVJjxzqI7jzeys5lXALcCmqhpt1hsZZ/xzwJs96n9RVW83s98C5g/eviRpOvR1zyHJjCR7gBFgR1XtBJYCa5LsTPJsklWT6OMm4Mmu+UVJXm62u2YS25UknYa+3udQVSeBFc19gW1JrmjGXgJcDawCtiZZXFU1SANJPge8DXy5Kb0OLKiqY0muArYnWVZVPxozbiOwEWDBggWD7FKSNIGBnlaqqreAZ4B1wDDwaHPZaRfwDjB3kO0l2QD8BvCpU6FSVaNVdayZfgl4lc5Zythe7q+qlVW1cmio57fcSZJOUz9PKw11PUk0B7gGOAhsB9Y29aXAbOCNfnecZB2dG9Afq6ofj9nfjGZ6MbAEeK3f7UqSJq+fM4d5wNNJ9gEv0rnn8DiwGVjcPKK6BdhQVZXksiRPnBqc5GHgBeDyJMNJPt0suhd4D7BjzCOrHwb2JdkLfAW4uapaN7QlSdNnwnsOVbUPuLJH/QRwY4/6EeC6rvkbxtnuB8apPwI8MlFfkqTp4zukJUkthoMkqcVwkCS1GA6SpBbDQZLUYjhIkloMB0lSi+EgSWoxHCRJLYaDJKnFcJAktRgOkqQWw0GS1GI4SJJaDAdJUovhIElqMRwkSS2GgySpZcJwSHJRkl1J9iY5kOSurmW3JTnU1O8ZZ/zmJCPNd0131/8wycEk+5JsS3Jx17I7kxxutv3RSRyfJOk09HPmMAqsraoPASuAdUmuTvKrwHpgeVUtA74wzvgHgXU96juAK6pqOfBXwJ0AST4IXA8sa8b9aZIZfR+RJGnSJgyH6jjezM5qXgXcAmyqqtFmvZFxxj8HvNmj/hdV9XYz+y1gfjO9HthSVaNV9T3gMLC6/0OSJE1WX/ccksxIsgcYAXZU1U5gKbAmyc4kzyZZNYk+bgKebKbfB/yga9lwU5MknSF9hUNVnayqFXT+d786yRXATOAS4GrgdmBrkgzaQJLPAW8DXz5V6tVCj3Ebk+xOsvvo0aOD7laS9C4Gelqpqt4CnqFzL2AYeLS57LQLeAeYO8j2kmwAfgP4VFWdCoBh4P1dq80HjvTo5f6qWllVK4eGhgbZrSRpAv08rTR06kmiJHOAa4CDwHZgbVNfCswG3uh3x0nWAZ8FPlZVP+5a9BhwfZILkywClgC7+t2uJGnyZvaxzjzgoeaJoQuArVX1eJLZwObmEdUTwIaqqiSXAQ9U1XUASR4G/hkwN8kw8G+r6r8A9wIXAjuaq1Hfqqqbq+pAkq3AK3QuN91aVSen8qAlSe9uwnCoqn3AlT3qJ4Abe9SPANd1zd8wznY/8C77vBu4e6LeJEnTw3dIS5JaDAdJUovhIElqMRwkSS2GgySpxXCQJLUYDpKkFsNBktRiOEiSWgwHSVKL4SBJajEcJEkthoMkqcVwkCS1GA6SpBbDQZLUYjhIkloMB0lSi+EgSWqZMBySXJRkV5K9SQ4kuatr2W1JDjX1e8YZvznJSJL9Y+qfbMa9k2RlV31hkp8k2dO87pvMAUqSBjezj3VGgbVVdTzJLOD5JE8Cc4D1wPKqGk1y6TjjHwTuBb40pr4f+G3giz3GvFpVK/roTZI0DSYMh6oq4HgzO6t5FXALsKmqRpv1RsYZ/1yShT3q3wFIclqNS5KmT1/3HJLMSLIHGAF2VNVOYCmwJsnOJM8mWTWFfS1K8nKz3TVTuF1JUh/6uaxEVZ0EViS5GNiW5Ipm7CXA1cAqYGuSxc2ZxmS8DiyoqmNJrgK2J1lWVT/qXinJRmAjwIIFCya5S0lSt4GeVqqqt4BngHXAMPBodewC3gHmTrahqhqtqmPN9EvAq3TOUsaud39VrayqlUNDQ5PdrSSpSz9PKw01ZwwkmQNcAxwEtgNrm/pSYDbwxmQbavY3o5leDCwBXpvsdiVJ/evnzGEe8HSSfcCLdO45PA5sBhY3j6huATZUVSW5LMkTpwYneRh4Abg8yXCSTzf130oyDPwy8PUkTzVDPgzsS7IX+Apwc1W9OTWHK0nqRz9PK+0DruxRPwHc2KN+BLiua/6Gcba7DdjWo/4I8MhEfUmSpo/vkJYktRgOkqQWw0GS1GI4SJJaDAdJUovhIElqMRwkSS2GgySpxXCQJLUYDpKkFsNBktRiOEiSWgwHSVKL4SBJajEcJEkthoMkqcVwkCS1GA6SpBbDQZLUMmE4JLkoya4ke5McSHJX17Lbkhxq6veMM35zkpEk+8fUP9mMeyfJyjHL7kxyuNn2R0/34CRJp2dmH+uMAmur6niSWcDzSZ4E5gDrgeVVNZrk0nHGPwjcC3xpTH0/8NvAF7uLST4IXA8sAy4DvpFkaVWd7POYJEmTNOGZQ3Ucb2ZnNa8CbgE2VdVos97IOOOfA97sUf9OVR3qMWQ9sKWqRqvqe8BhYHU/ByNJmhp93XNIMiPJHmAE2FFVO4GlwJokO5M8m2TVFPX0PuAHXfPDTU2SdIb0FQ5VdbKqVgDzgdVJrqBzSeoS4GrgdmBrkkxBT722Ua2Vko1JdifZffTo0SnYrSTplIGeVqqqt4BngHV0/kf/aHPZaRfwDjB3CnoaBt7fNT8fONKjl/uramVVrRwaGpqC3UqSTunnaaWhJBc303OAa4CDwHZgbVNfCswG3piCnh4Drk9yYZJFwBJg1xRsV5LUp37OHOYBTyfZB7xI557D48BmYHHziOoWYENVVZLLkjxxanCSh4EXgMuTDCf5dFP/rSTDwC8DX0/yFEBVHQC2Aq8Afw7c6pNKknRmTfgoa1XtA67sUT8B3NijfgS4rmv+hnG2uw3YNs6yu4G7J+pNkjQ9fIe0JKnFcJAktRgOkqQWw0GS1GI4SJJaDAdJUovhIElqMRwkSS2GgySpxXCQJLUYDpKkFsNBktRiOEiSWgwHSVKL4SBJajEcJEkthoMkqcVwkCS1TBgOSS5KsivJ3iQHktzVtey2JIea+j3jjN+cZKT5runu+s8l2ZHku83PS5r6wiQ/SbKned032YOUJA1mwu+QBkaBtVV1PMks4PkkTwJzgPXA8qoaTXLpOOMfBO4FvjSmfgfwzaralOSOZv6zzbJXq2rFYIciSZoqE545VMfxZnZW8yrgFmBTVY02642MM/454M0ei9YDDzXTDwEfH6hzSdK06eueQ5IZSfYAI8COqtoJLAXWJNmZ5Nkkqwbc9y9U1esAzc/uM49FSV5utrtmwO1Kkiapn8tKVNVJYEWSi4FtSa5oxl4CXA2sArYmWVxVNcmeXgcWVNWxJFcB25Msq6ofda+UZCOwEWDBggWT3KUkqdtATytV1VvAM8A6YBh4tLnstAt4B5g7wOZ+mGQeQPNzpNnHaFUda6ZfAl6lc5Yytpf7q2plVa0cGhoa5DAkSRPo52mloeaMgSRzgGuAg8B2YG1TXwrMBt4YYN+PARua6Q3AV7v2N6OZXgwsAV4bYLuSpEnq58xhHvB0kn3Ai3TuOTwObAYWN4+obgE2VFUluSzJE6cGJ3kYeAG4PMlwkk83izYB1yb5LnBtMw/wYWBfkr3AV4Cbq6rXDW1J0jSZ8J5DVe0DruxRPwHc2KN+BLiua/6GcbZ7DPi1HvVHgEcm6kuSNH18h7QkqcVwkCS1GA6SpBbDQZLUYjhIkloMB0lSi+EgSWoxHCRJLYaDJKnFcJAktRgOkqQWw0GS1GI4SJJaDAdJUovhIElqMRwkSS2GgySpxXCQJLUYDpKklgnDIclFSXYl2ZvkQJK7upbdluRQU79nnPGbk4wk2T+m/nNJdiT5bvPzkq5ldyY53Gz7o5M5QEnS4Po5cxgF1lbVh4AVwLokVyf5VWA9sLyqlgFfGGf8g8C6HvU7gG9W1RLgm808ST4IXA8sa8b9aZIZfR+RJGnSJgyH6jjezM5qXgXcAmyqqtFmvZFxxj8HvNlj0XrgoWb6IeDjXfUtVTVaVd8DDgOr+zoaSdKU6OueQ5IZSfYAI8COqtoJLAXWJNmZ5Nkkqwbc9y9U1esAzc9Lm/r7gB90rTfc1CRJZ0hf4VBVJ6tqBTAfWJ3kCmAmcAlwNXA7sDVJpqCnXtuo1krJxiS7k+w+evToFOxWknTKQE8rVdVbwDN07gUMA482l512Ae8AcwfY3A+TzANofp66LDUMvL9rvfnAkR693F9VK6tq5dDQ0CCHIUmaQD9PKw0lubiZngNcAxwEtgNrm/pSYDbwxgD7fgzY0ExvAL7aVb8+yYVJFgFLgF0DbFeSNEn9nDnMA55Osg94kc49h8eBzcDi5hHVLcCGqqoklyV54tTgJA8DLwCXJxlO8ulm0Sbg2iTfBa5t5qmqA8BW4BXgz4Fbq+rkVBysJKk/Mydaoar2AVf2qJ8AbuxRPwJc1zV/wzjbPQb82jjL7gbunqg3SdL08B3SkqQWw0GS1GI4SJJaDAdJUovhIElqMRwkSS2GgySpxXCQJLUYDpKkFsNBktRiOEiSWgwHSVKL4SBJajEcJEkthoMkqcVwkCS1GA6SpBbDQZLUYjhIklomDIckFyXZlWRvkgNJ7upadluSQ039nnHGr2vWOZzkjq76h5K8kOTbSb6W5L1NfWGSnyTZ07zum4oDlST1b2Yf64wCa6vqeJJZwPNJngTmAOuB5VU1muTSsQOTzAD+BLgWGAZeTPJYVb0CPAD8XlU9m+Qm4Hbg883QV6tqxWQPTpJ0eiY8c6iO483srOZVwC3ApqoabdYb6TF8NXC4ql6rqhPAFjqBAnA58FwzvQP4xGkfhSRpSvV1zyHJjCR7gBFgR1XtBJYCa5LsTPJsklU9hr4P+EHX/HBTA9gPfKyZ/iTw/q71FiV5udnumv4PR5I0FfoKh6o62VzmmQ+sTnIFnUtSlwBX07kktDVJxgwdOw+dsw6Am4Bbk7wEvAc40dRfBxZU1ZXAvwL+26n7EX9nw8nGJLuT7D569Gg/hyFJ6tNATytV1VvAM8A6OmcBjzaXnXYB7wBzxwwZ5u+eEcwHjjTbOlhVH6mqq4CHgVeb+mhVHWumX2rqS3v0cn9VrayqlUNDQ4MchiRpAv08rTSU5OJmeg5wDXAQ2A6sbepLgdnAG2OGvwgsSbIoyWzgeuCxZsylzc8LgN8H7uva34xmejGwBHhtMgcpSRpMP08rzQMean5hXwBsrarHm1/2m5Psp3NJaENVVZLLgAeq6rqqejvJZ4CngBnA5qo60Gz3hiS3NtOPAn/WTH8Y+PdJ3gZOAjdX1ZtTcbCSpP5MGA5VtQ+4skf9BHBjj/oR4Lqu+SeAJ3qs98fAH/eoPwI8MlFfkqTp4zukJUkthoMkqcVwkCS1GA6SpBbDQZLUYjhIkloMB0lSi+EgSWoxHCRJLYaDJKnFcJAktRgOkqQWw0GS1GI4SJJaDAdJUovhIElq6eeb4H7mfX/Tr5/tFiTpnOKZgySpZcJwSHJRkl1J9iY5kOSurmW3JTnU1O8ZZ/y6Zp3DSe7oqn8oyQtJvp3ka0ne27Xszmb9Q0k+OtmDlCQNpp/LSqPA2qo6nmQW8HySJ4E5wHpgeVWNJrl07MAkM4A/Aa4FhoEXkzxWVa8ADwC/V1XPJrkJuB34fJIPAtcDy4DLgG8kWVpVJyd/uJKkfkx45lAdx5vZWc2rgFuATVU12qw30mP4auBwVb1WVSeALXQCBeBy4LlmegfwiWZ6PbClqkar6nvA4WY7kqQzpK97DklmJNkDjAA7qmonsBRYk2RnkmeTrOox9H3AD7rmh5sawH7gY830J4H39zFGknQG9BUOVXWyqlYA84HVSa6gc0nqEuBqOpeEtibJmKFj56Fz1gFwE3BrkpeA9wAn+hjz0w0nG5PsTrL76NGj/RyGJKlPAz2tVFVvAc8A6+j8j/7R5rLTLuAdYO6YIcP89IwAOuFypNnWwar6SFVdBTwMvDrRmDG93F9VK6tq5dDQ0CCHIUmaQD9PKw0lubiZngNcAxwEtgNrm/pSYDbwxpjhLwJLkixKMpvOjebHmjGXNj8vAH4fuK8Z8xhwfZILkywClgC7Tv8QJUmD6udppXnAQ82TRxcAW6vq8eaX/eYk++lcEtpQVZXkMuCBqrquqt5O8hngKWAGsLmqDjTbvSHJrc30o8CfAVTVgSRbgVeAt4FbfVJJks6sVLUu5593khwF/voM73Yu7TOlc9n51i/Y85lwvvUL9jyVfrGqel6X/5kIh7Mhye6qWnm2++jX+dYv2POZcL71C/Z8pvjxGZKkFsNBktRiOJy++892AwM63/oFez4Tzrd+wZ7PCO85SJJaPHOQJLX4ZT9dkvx3Oh8ICHAx8FZVrUiyEPgOcKhZ9q2qunmA8Z+i8xEjpywH/nFV7TlXe26WLQe+CLyXzjvgV1XV356rPfc7/lzpt2v5Ajrv6/l3VfWFyfY7nT0nWc1PL5Gk6XnbOd7ztcAmOm/UPQHcXlX/4xzu9+eBrwCrgAer6jOT7fV0GA5dqup3Tk0n+Y/A/+la/Gr3P+hBxlfVl4EvN/V/BHx1KoJhOntOMhP4r8C/qKq9zV/Y/3su99zv+EFNc78AfwQ8OflO+97nZHreD6xs3uA6D9ib5GtV9fY53PMbwG9W1ZHmc+GeYgo+zHMa+/1b4PPAFc3rrDAcemg+QPCf03w8yBSPv4HOZ0lNqWno+SPAvqraC1BVx6aizwn2eUbHn+n99Rqf5OPAa8DfTEGLfe1zMuOr6sddiy+ix4diTtY09Pxy1+IDwEVJLjz1dQOTNQ39/g2d7835wFT0d7q859DbGuCHVfXdrtqiJC83H0++5jTGn/I7TEM4jLPPyfS8FKgkTyX5yyT/+jzoedDxZ7XfJH8f+Cxw17uOmpwp/zNO8ktJDgDfBm6eirOG6e65yyeAl6cqGN5lf1PV71nz/92ZQ5JvAP+gx6LPVdVXm+mx/7t/HVhQVceSXAVsT7Ksqn40zm56nh0k+SXgx1W1/zzoeSbwK3Sue/4Y+GaSl6rqm+dwz4OOP9v93gX8UXW+ZXGiFs+VnqnO97ksS/IP6Xzu2pP93os6y//+lgF/QOesuC9ns9+zrqp8db3o/FL8ITD/XdZ5hs5114HG07m2/G/Oh57pfILug13zn6dzI++c7XmQ8edCv8D/BL7fvN4C3gQ+c579GT89VX/G09kznY/+/yvgn0xVr9P9Zwz8LnDvVPY7yMvLSm3XAAeravhUIZ2PLZ/RTC+m8zHir/U7vhl3AZ1vvNtynvT8FLA8yd9L5+b0P6XzRM052/OA4896v1W1pqoWVtVC4D8D/6Gq7p2ifqel53Q+fn9mM/2LdJ62+f453vPFwNeBO6vqf01hr9PS77nCcGi7nvYp3oeBfUn20nnE7OaqehMgyQNJVk4w/tQ2hqtqqn5ZTWvPVfW/gf9E5zs59gB/WVVfP5d7frfx52i/0206ev4VOk8o7QG2Af+yqqby00ano+fPAB8APp9kT/O69BzulyTfp/Pv73eTDCf54BT12zffIS1JavHMQZLUYjhIkloMB0lSi+EgSWoxHCRJLYaDJKnFcJAktRgOkqSW/wfQHnDDjKMW6QAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "geojson_bbox=create_geodataframe_from_bbox(shapes_list)\n",
+    "if (geojson_bbox is not None):\n",
+    "    print(f\"Geojson bounds\\n{geojson_bbox.bounds}\\n\")\n",
+    "else:\n",
+    "    print(\"ERROR.\\nYou must draw a bounding box somewhere on the coast first.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13647ccc-71f7-462c-9232-24a1989d3a5f",
+   "metadata": {},
+   "source": [
+    "### Download the Shorline Vector\n",
+    "- https://geodata.lib.berkeley.edu/catalog/stanford-xv279yj9196"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "7e5ba349-7a86-443c-992b-1760a42adaf3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_shoreline_vector(filename:str)->\"geopandas.geodataframe.GeoDataFrame\":\n",
+    "    if os.path.exists(filename):\n",
+    "         with open(filename, 'r') as f:\n",
+    "            coastline_vector=gpd.read_file(f)\n",
+    "    else:\n",
+    "        print('File does not exist. Please download the coastline_vector necessary here: https://geodata.lib.berkeley.edu/catalog/stanford-xv279yj9196 ')\n",
+    "        raise FileNotFoundError\n",
+    "    return coastline_vector      "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "54ef4bb4-d28b-4f68-aff2-d30131f14f47",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>f_code</th>\n",
+       "      <th>acc</th>\n",
+       "      <th>exs</th>\n",
+       "      <th>soc</th>\n",
+       "      <th>geometry</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>xv279yj9196.1</td>\n",
+       "      <td>BA010</td>\n",
+       "      <td>1</td>\n",
+       "      <td>44</td>\n",
+       "      <td>USA</td>\n",
+       "      <td>MULTILINESTRING ((-96.93882 28.02606, -96.9354...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>xv279yj9196.2</td>\n",
+       "      <td>BA010</td>\n",
+       "      <td>1</td>\n",
+       "      <td>44</td>\n",
+       "      <td>USA</td>\n",
+       "      <td>MULTILINESTRING ((-96.91022 28.06370, -96.9123...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>xv279yj9196.3</td>\n",
+       "      <td>BA010</td>\n",
+       "      <td>1</td>\n",
+       "      <td>44</td>\n",
+       "      <td>USA</td>\n",
+       "      <td>MULTILINESTRING ((-96.89713 28.06679, -96.8990...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>xv279yj9196.4</td>\n",
+       "      <td>BA010</td>\n",
+       "      <td>1</td>\n",
+       "      <td>44</td>\n",
+       "      <td>USA</td>\n",
+       "      <td>MULTILINESTRING ((-96.88841 28.07634, -96.8849...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>xv279yj9196.5</td>\n",
+       "      <td>BA010</td>\n",
+       "      <td>1</td>\n",
+       "      <td>44</td>\n",
+       "      <td>USA</td>\n",
+       "      <td>MULTILINESTRING ((-96.91283 28.12183, -96.9144...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3094</th>\n",
+       "      <td>xv279yj9196.3095</td>\n",
+       "      <td>BA010</td>\n",
+       "      <td>1</td>\n",
+       "      <td>44</td>\n",
+       "      <td>USA</td>\n",
+       "      <td>MULTILINESTRING ((-160.08739 22.02016, -160.08...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3095</th>\n",
+       "      <td>xv279yj9196.3096</td>\n",
+       "      <td>BA010</td>\n",
+       "      <td>1</td>\n",
+       "      <td>44</td>\n",
+       "      <td>USA</td>\n",
+       "      <td>MULTILINESTRING ((-159.39618 22.22735, -159.39...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3096</th>\n",
+       "      <td>xv279yj9196.3097</td>\n",
+       "      <td>BA010</td>\n",
+       "      <td>1</td>\n",
+       "      <td>44</td>\n",
+       "      <td>USA</td>\n",
+       "      <td>MULTILINESTRING ((-130.01769 55.91194, -130.02...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3097</th>\n",
+       "      <td>xv279yj9196.3098</td>\n",
+       "      <td>BA010</td>\n",
+       "      <td>1</td>\n",
+       "      <td>44</td>\n",
+       "      <td>USA</td>\n",
+       "      <td>MULTILINESTRING ((-160.87141 56.00000, -160.86...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3098</th>\n",
+       "      <td>xv279yj9196.3099</td>\n",
+       "      <td>BA010</td>\n",
+       "      <td>1</td>\n",
+       "      <td>44</td>\n",
+       "      <td>USA</td>\n",
+       "      <td>MULTILINESTRING ((-146.31833 59.43345, -146.30...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>3099 rows × 6 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                    id f_code  acc  exs  soc  \\\n",
+       "0        xv279yj9196.1  BA010    1   44  USA   \n",
+       "1        xv279yj9196.2  BA010    1   44  USA   \n",
+       "2        xv279yj9196.3  BA010    1   44  USA   \n",
+       "3        xv279yj9196.4  BA010    1   44  USA   \n",
+       "4        xv279yj9196.5  BA010    1   44  USA   \n",
+       "...                ...    ...  ...  ...  ...   \n",
+       "3094  xv279yj9196.3095  BA010    1   44  USA   \n",
+       "3095  xv279yj9196.3096  BA010    1   44  USA   \n",
+       "3096  xv279yj9196.3097  BA010    1   44  USA   \n",
+       "3097  xv279yj9196.3098  BA010    1   44  USA   \n",
+       "3098  xv279yj9196.3099  BA010    1   44  USA   \n",
+       "\n",
+       "                                               geometry  \n",
+       "0     MULTILINESTRING ((-96.93882 28.02606, -96.9354...  \n",
+       "1     MULTILINESTRING ((-96.91022 28.06370, -96.9123...  \n",
+       "2     MULTILINESTRING ((-96.89713 28.06679, -96.8990...  \n",
+       "3     MULTILINESTRING ((-96.88841 28.07634, -96.8849...  \n",
+       "4     MULTILINESTRING ((-96.91283 28.12183, -96.9144...  \n",
+       "...                                                 ...  \n",
+       "3094  MULTILINESTRING ((-160.08739 22.02016, -160.08...  \n",
+       "3095  MULTILINESTRING ((-159.39618 22.22735, -159.39...  \n",
+       "3096  MULTILINESTRING ((-130.01769 55.91194, -130.02...  \n",
+       "3097  MULTILINESTRING ((-160.87141 56.00000, -160.86...  \n",
+       "3098  MULTILINESTRING ((-146.31833 59.43345, -146.30...  \n",
+       "\n",
+       "[3099 rows x 6 columns]"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "coastline_vector=get_shoreline_vector(\"stanford-xv279yj9196.geojson\")\n",
+    "coastline_vector"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "250bf434-4d94-4649-8398-ab0daac405b1",
+   "metadata": {},
+   "source": [
+    "### Clip the shorline vector to the bounding box"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "5f942a63-4785-4903-8a83-d2aad04afb58",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def clip_coastline_to_bbox(coastline_vector, geojson_bbox)->\"geopandas.geodataframe.GeoDataFrame\":\n",
+    "    #clip coastal polyline\n",
+    "    roi_coast=gpd.clip(coastline_vector, geojson_bbox)\n",
+    "    roi_coast=roi_coast.to_crs('EPSG:4326')\n",
+    "    return roi_coast"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "00058a58-5ffe-41bf-9f44-137a53fac4fa",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>f_code</th>\n",
+       "      <th>acc</th>\n",
+       "      <th>exs</th>\n",
+       "      <th>soc</th>\n",
+       "      <th>geometry</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1889</th>\n",
+       "      <td>xv279yj9196.1875</td>\n",
+       "      <td>BA010</td>\n",
+       "      <td>1</td>\n",
+       "      <td>44</td>\n",
+       "      <td>USA</td>\n",
+       "      <td>MULTILINESTRING ((-75.72433 36.12640, -75.7236...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                    id f_code  acc  exs  soc  \\\n",
+       "1889  xv279yj9196.1875  BA010    1   44  USA   \n",
+       "\n",
+       "                                               geometry  \n",
+       "1889  MULTILINESTRING ((-75.72433 36.12640, -75.7236...  "
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "roi_coast=clip_coastline_to_bbox(coastline_vector, geojson_bbox)\n",
+    "roi_coast"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84288be5-4ca1-4058-8f9c-974a2e8bf7c4",
+   "metadata": {},
+   "source": [
+    "## Display the Shoreline Vector"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "49c08a52-adb1-4b73-b7ba-4d6aaf667441",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAASAAAAD4CAYAAABMmTt2AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAArOklEQVR4nO3deXxcV3nw8d+ZRTNaR7tkrZYseZcXWV7iJYmd3QGymCQOpS+8tEBK6AJveYHSvm3fQqFvS8uHN9BAaIAWEpPETgLZIaudxHa825I3Sd5kyYska7N26fSPuTKKLdmaO8u9o3m+n48+Hs3MvfcZW350zrnnnEdprRFCCCs4rA5ACBG7JAEJISwjCUgIYRlJQEIIy0gCEkJYxmV1AKGQmZmpp06danUYQogx7Ny5s1lrnTXWa5MiAU2dOpUdO3ZYHYYQYgxKqRPjvSZdMCGEZSQBCSEsIwlICGEZSUBCCMtIAhJCWEYSkBDCMpKAhBCWifkENDA0fNXXtdbXfI+wr+FhjWw5Y18xn4C+tnE/X3xi15g/pH2DQ6z/8Va+//rRsF3/4V/u4nu/OxK288eyI2c7ufnf3mbniQtWhyLGEdMJqKaxg027G8hPjUcpdcXrHpeTnBQvj22up6m9J+TXHxrWvH7oLJ29gyE/t4CCtHhauvp5bHO91aGIccR0Avr2ywdJ8br5wo1l477nf98+g2EN//zq4ZBf/1hzF70Dw8yekhLycwtIiHPxyWVFvFZzluPNF60OR4whZhPQO0fOs/loM3+6pgxfgnvc9xWkJfCZFSVs2nWa/Q3tIY2hurEDgDn5koDC5VPXTcXtcPD4u8esDkWMISYT0NCw5tsvH6IgLZ4/vK74mu//wupppCfG8c0Xa0I6oFnd2EGcy8G0rKSQnVN8WHaKl48tyOPpHQ20dfdbHY64zDUTkFLKq5TarpTaq5SqVkr9/ajX/lQpddh4/v+Nc/zjSqlzSqkDlz3/z0qpQ0qpfUqpZ5VSqcbzU5VSPUqpPcbXo0F+xis8t/s0B5s6+MptM/C4nNd8f4rXzZdumc62Y638tuZsyOKoaexgRk4ybmdM/h6ImD9eVULPwBC/3HbS6lDEZSbyk98HrNFazwcWALcrpZYppVYDdwHztNZzgH8Z5/ifAbeP8fxvgbla63nAEeDro16r01ovML4emthHmZjegSG++9ph5hX4+Oi8vAkf9+DiQsqyk/jOy4dCcltea011Yztz8qT7FW4zc1NYVZ7Jz947Tt/gkNXhiFGumYC0X5fxrdv40sCfAN/RWvcZ7zs3zvHvAK1jPP+a1nrk9s9WoCDw8AP303eP09jey9fumInDceWdr/G4nA7+au1M6psv8out425vMmFN7b1c6B5gtiSgiPjMyhLOd/bx+sExf0yFRSbU9ldKOZVSe4BzwG+11tuA6cAqpdQ2pdTbSqnFQcTxGeDlUd+XKKV2G+ddNU5Mn1NK7VBK7Th//vyELtJ6sZ8fvlnLmpnZLJ+WGXCQq2dks7QknZ++ezzgYy9XMzIALQkoIq4vzyInxcPGnQ1WhyJGmVAC0loPaa0X4G+lLFFKzcW/m2IasAz4CvCUGmsyzTUopb4BDAK/NJ5qAoq01guBLwNPKKWu+F+qtf6x1rpKa12VlTXmbo9XeGFfI519g3zlthmBhjkSK2srpnCytZuTLd2mzjGiurEDpfzdAxF+Tofi7oX5vHXkPM1dfVaHIwwBjX5qrduAt/CP6TQAm4wu2nZgGAioWaGU+hTwEeAPtHF7SWvdp7VuMR7vBOrwt7aC1tEzABDUXaeV5f6PuLl2Yq2u8dQ0tVOSkUiiZ1LsihsV1lUWMDSseX5Po9WhCMNE7oJljbpDFQ/cDBwCngPWGM9PB+KA5oleWCl1O/BV4GNa6+5Rz2cppZzG41KgHAjJVNaegSGcDoXbGXBD7ZLSzETyfF62HJ3wRx1TdWOHjP9E2PScZCryfWzaJd0wu5hIC2gK8KZSah/wAf4xoBeAx4FS4/b6BuBTWmutlMpTSr00crBS6kngfWCGUqpBKfVHxkuPAMnAby+73X49sE8ptRd4BnhIa33FILYZPf3DxLudYy67mCilFCvLM3mvroWhYXNzgtq7B2i40CMJyALrKvOpbuzg0JkOq0MRTKAqhtZ6H7BwjOf7gU+O8XwjsHbU9w+Oc94x1z9orTcCG68Vlxk9A0N43dee93MtK8uzeGpHA/tPt7OgMDXg42uaRgagfUHHIgLz0fl5fPPFg2zadZq/Wiu/AKwWUzPg+gaGiI8L/iOvmJYBwJaj5saBqhv9SzpkDVjkZSR5WD0zm2d3n2ZQtlmxXEwloJ6BIeJD0ALKSPIwJy+FzSbHgWoaO8hO9pCV7Ak6FhG4dZX5nO/sY3NtcON4IniSgExaWZ7JrpMXuNgX+FYaNU0dMv/HQqtnZpOa4GbTrtNWhxLzYisB9YdmDAhgVVkWA0Oa7ccCHx9v7urDFz/+CnwRXh6Xk4/Oy+O16jN09A5YHU5Mi6kE1BuiQWiAqqlpxLkcvF/fEvCxlUVp7JBd+iy1blEBfYPDvLSvyepQYlpMJaBQdsG8biezcpNN7RG0oiyThgs9Qc+mFubNL/AxLSuRjTInyFIxl4C87tB95IoCHwdOtzMc4HygFWX+u2jv1skgqFWUUtxbWcAHxy9wokV2S7RKTCWgtIQ49pxqC1mVi3n5qXT2DXI8wB/gaVlJZCd7eK8u8O6bCJ17FuajFDIYbaGYSkB/uqac4y3dbNgemo2p5ub7JxLuPx1YN0wpxfJpGbxf1ywlYyyUlxrP8mkZbNrdEHArVoRGTCWgm2f5t9P43u+O0hmCux/lOUl4XA5T40DLyzJp7urn8NnOoOMQ5q2rLOBUa4/cFLBITCUgpRTfuHMWLRf7+dHbwa9vdTsdzM5LYV+ALSCA5cZs6vdqpRtmpdvm5JIQ55R9giwSUwkIYF5BKnctyAtZra+KfB/VJgaiC9ISKM5I4D0ZiLZUosfFHXOn8OL+JnoHZLvWSIu5BATwl7fOQGv47mvBVyStyPdxsX+IehN1p5ZPy2RbfausSbLYusp8uvoGebX6jNWhxJyYTECF6Qn8zxVT2bir4dLWqGbNK0gFYP/ptoCPXVGWQWffoKkunAidZaUZ5KfG8/QO6YZFWkwmIIAvrC7DF+/mH186GNSdqGlZicS7newzMRB9Xal/HOh9uR1vKYdDcV9VAe/WNXOqVSaHRlLMJiBfvJs/W1POltpm3j5ifntVlzEQfcBEKyYjycPM3GTelVXZlvv4In9RlmdkMDqiYjYBAXxyWTHFGQl8+6VDpnc3BP840IHTHabOsaIskx0nLsgAqMUK0hJYWZbJMztlTlAkxXQCinM5+OrtMzl8tpPn95ifDTuvwEfPwBB157uu/ebLrCjLoH9wmF0yD8Vy91cVcrqtR5bIRFBMJyCAO+bmkp8azysHzN8BqTBmRJsZB1o8NR2nQ8kPvQ3cMjsHX7ybp2QwOmJsVxveeO3rSqla49y3BfH5rkkpxaryTN6vazF9O7w0K4mEOKepcaBkr5v5BT7elQmJlvO6ndyzMJ9Xq8/Q1t1vdTgxwXa14ZVSs4H1wBzjuB+OlOkJl5XlmXT2DbLXRAsG/EXv5ub52NfQZur4FWWZ7GtoC8nyEBGc+6oK6B8cltphEWLH2vB3ARuMAoXHgFpgycQ/UuBWTMtEKYKq9TU330dNU4epVtR1pRkMa9hxXMaBrDYnz8fc/BR+9cEpq0OJCXasDZ8PjP7XbzCeuzymgGvDjyctMY65eT62BFHtdF6Bj96BYWpNDEQvLEojzulg6zHphtnB/VWF1DR1mOpSi8DYsTb8WOe44r6omdrwV7OyPJPdJ9voMrHJPPg3JwNzA9HxcU7mF/rYWh+S+osiSHfNzyfO5eCpHdIKCjfb1YY3zls46m0FQNg75KvKMhkc1mw1OSu5JCORJI/L1NYc4F8OcOB0u+kEKELHl+Dm9jm5PLf7tMzPCjPb1YYHfg2sV0p5lFIl+GvDb5/oec1aNDUNr9vBFpOzkh0OxZy8lIA3JxuxtCSDoWHNjuPSCrKDBxYX0tE7yGs1Z60OZVKzXW14rXU18BRQA7wCPKy1DvuvIY/LyZKSDDabrHYK/nGgmqYOU1u+Vhan4nYq6YbZxHWlGRSkxfOUDEaHle1qwxuvfQv41rViC7VVZZl866WDNLX3MMUXH/Dxc/N99A8Oc+RsZ8B13xPiXMwvSGWriTI/IvQcDsV9iwr53utHONXaTWF6gtUhTUoxPxN6tJXl/iEssyWXL23NYXIcaGlpOvtPt5uqtipC7+NVskA13CQBjTIzN5nMJI/p+UDF6Qkke12mx4GWlRrjQLIuzBbyU+NlgWqYSQIaRSnFyrIM3q1tNvUD5zBmRJtNQIuK03A5FNukG2YbskA1vCQBXWZleRYtF/s5dMZctYp5BT4ONXXSPxj4QHRCnIt5BT4ZB7KRW+fkkJogC1TDRRLQZVaW+ceBzM6Krijw0T/kH4g2Y1lpBvsa2unul3EgO/C4nNy9QBaohoskoMvk+ryUZyeZH4jOTwXMzYgGfwIaHNbslHEg27i/qlAWqIaJJKAxrCzPZPuxVvoGA59+VJgejy/ebWqTevCPAzkdSrphNjI7L0UWqIaJJKAxLJmaTt/gsKmKGUopKvLND0QnelxMz0kOulqHCK0HZIFqWEgCGkNlcRqA6W5QRYGPw2c6Ta8jykyKo7Vb9gayk48tyMfjckgrKMQkAY0hJ8VLfmo8u0+2mTq+It/HwJDmsMk7aRmJcbRe7DN1rAgPX7ybtRVTeG7PaXr6ZYFqqEgCGkdlcRq7TppsARl7RJvthqUlxtHaJXdc7Gb94kI6ewd5cX+T1aFMGpKAxlFZlEpTe6+p+vEFafGkJbhNL8nISIzjYv+QbAVhM0tK0inNSmTD9pNWhzJpSAIaR2WRfxxo14m2gI9VSlFRkGq65HJ6ogeACzLvxFaUUqxfXMiOExc4anKel/gwSUDjmDUlBY/LYX4gOj+Fo2fNDUSnJ7oBaJFumO2sqyzA7VRskMHokJAENI44l4N5Bb4gxoFSGRzWHGwK/Ha6tIDsKyPJw62zc9m0q8HUPDHxYZKArqKyOI3qxnZTrZh5BeYHotMT4wBovSgJyI7WLynkQvcAr1bLbonBkgR0FZVFaQwMaaobA08iU3xeMhLjTC3JGElA0gWzpxXTMilMj5fB6BCQBHQVwQ9E+0zNnE2Nd+NQ0gWzK4dD8UBVIe/VtXCi5aLV4UQ1SUBXkZXsoTA93vRA9Lx8H0fOdgY8cc3hUKQlxNEiXTDbuq+qEKdDBqODZWVt+PuM44aVUlWjnp+qlOoxNqq/tFm9VSqL/BMSf181aOIqClIZ1lDTZK4bJpMR7SsnxcvqGdk8vaPBVBEC4WdlbfgDwL3AO2O8Vqe1XmB8PTSBGMNmUXEa5zr7ON0W+ITESzOiTYwDpSXG0SpdMFt7cEkhzV19vH5wzKrkYgKsrA1/UGt92GzgkXJpHMjEurCcFA9ZyR5TExL968EkAdnZDdOzyE3xsuEDGYw2yy614S9XopTabZx31Tgxhaw2/NXMzE0m3u1kl4lxIKUU8/J9plpA6ZKAbM/ldHB/VQFvHzlvqoUsbFAbfgxNQJHWeiHwZeAJpVTKGDGFtDb8eFzO4CYkzs33UXe+K+BSO+mJcVzo7mdIqjHY2v2L/VXEpYChOZbWhh/nGn1a6xbj8U6gDn9ryzKVxWnUNHaYnpDoH4gObEb0jNxktEZ2RrS5grQEVpVn8fSOU/LLwgTLasNf43pO43Ep/trw9cGeNxiLitIYHNamJhWODEQHeuzNs3JI9rrYuEuqMdjdg4sLaWzv5Z0j4RsKmKwsqw2vlLpHKdUAXAe8qJR61TjkemCfUmov8AzwkNba0oLpC4tSAUx1w7JTvOSmeAOekOh1O/nIvCm8cuCMVEq1uZtm5ZCZFMeTMjM6YFbWhn8WeHaM5zcCG68VVyRlJHmYmpFgaiAa/ONAe0+1BXzcusoCntx+ipcPnOHjiwpMXVuEX5zLwbpFBfxk8zHOdfSSneK1OqSoITOhJyiYCYnLStOpb77I8ebApu0vKk6jOCOBjVKb3PbWLy5iaFjztPxbBUQS0AQtLE6juaufU62B325dWzEFIOCtPJVS3LuwgPfrW2i40B3wdUXklGQmsqw0nQ0fnJQ68gGQBDRBiy5NSAy8G5aXGk9lUSov7gt8L+F7K/MBeG736YCPFZH14JIiTrX28F6d3LmcKElAEzQjN5nEOKfp+UBrK6ZQ09TBsQC7YYXpCSwtSWfjrtOmun8icm6bk0tqgpsnZWb0hEkCmiCnQzG/MNX0yviRbthLJioqrFtUwLHmi6aWg4jI8bqdrKss4NUDZ2TP6AmSBBSAquI0DjZ10NkbeNHAvNR4FhWn8YKJbtjaiinEu50yJygKfOHGaSR6XHzjuQPSYp0ASUABWFqawbCGHUG0gg42dVB/vuvabx4lyePi9rm5vLC3UUr12FxGkoev3TGT7cda2bhLxu2uRRJQACqL0nA5FNvqzc2LXFuRC5jrht1bmU9H76Bs/RAFHqgqpLIolX986SBtsqXKVUkCCkB8nJN5BT62HzN3l2OKz3w3bPm0THJTvNINiwIOh+Kbd1fQ3jPAP71i+x1nLCUJKEBLSzPY19BOd7+55RF3Vkzh0JlO6gLshjkdirsX5vP2kfPyWzUKzM5L4dPLp/Lk9pOm75zGAklAAVpaks7gsDa1UT3AHSPdMBOtoNvm5DA0rHlbFj1GhS/dMp3cFC/fePYAg7Jt65gkAQVoUXEaDkVQ3bCq4rSAZ0UDzC9IJSMxjjcOyThQNEjyuPjbj87mYFMHP3//hNXh2JIkoAAle93Mzfex9Zj5Bfp3zvN3w2rPBdYNczgUq2dm89bh8/IbNUrcPjeXG2dk8a+vHaapXXZNvJwkIBOWlqSz51Sb6Vvid8w1PynxppnZtPcMyKTEKKGU4v9+bC6Dw5p/eKHG6nBsRxKQCUtKMugfHDa1xQZArs/L4qlpphLQyvJM3E7F64ekLHC0KMpI4Iury3hp/xneOizd59EkAZmwZGo6SsG2ILphaytGumGBTdlP9rpZUpLOGzIfKKp87oZSSrMS+T/PV8tk0lEkAZngS3AzMzeFbSYHosE/NgCYmli4ZmYOR891capVtuiIFh6Xk2/eNZeTrd388M1aq8OxDUlAJi0tSWfniQv0D5obDJ7ii6c8O4kttYFvo33TzGwAuRsWZZaXZXL3gjz+/e26gOeBTVaSgExaWpJO78Aw+00UHRyxsjyT7cdaA26ST81MpDQzkdclAUWdb9w5G4/LySNvSCsIbFgb3njt60qpWuPct5n9cOG0pCQdIKhu2KryTPoGh9lxPPCZsmtmZrO1rkU2rI8yWckePjo/T4oNGGxXG14pNRtYD8wxjvvhSJkeO8lI8lCWncT2IAail5Zk4HYqNtcGPrN5zaxs+oeGTXXhhLXurcynZ2CIV6vPWB2K5exYG/4uYINRoPAYUAssmciHibSlJensOH7B9KTARI+LhUVpbDkaeBJZPDWdZI9L7oZFoariNArT43lWttm1ZW34fGB0ndsG47nLY4pIbfirWVqaQVffYMBVT0dbVZZJdWMHLV19AR3ndjq4fkYWbxw+J5ugRxmlFPcsyOfd2mbOdvRaHY6l7FgbfqxzXPE/LFK14a9myVT/OJDZemHgH4gGeNfERuZrZmRzvrOPA43mB8KFNe6pLGBYw/N7YrsVZLva8MZ5C0d9XwA0huC8IZeT4iHZ66I+wI3mR5tXkEqK18WWo4G34m6ckYVScjs+GpVkJrKgMJVNMb5rou1qwwO/BtYrpTxKqRL8teG3h+C8IaeUojQzMeBKF6M5HYrl0zLZcrQ54D2EM5I8LCxMlQQUpe6tzOfQmU4OBtGFj3a2qw2vta4GngJqgFeAh7XWtp27XpqVRP158wkI/N2wxvZeUy2p2Xkp1AW4ql7Yw0fm5eFyqJgejLZdbXjjtW8B37pWbHZQkpnIs7tP0zswhNdtbrbAKmMcaMvRZqZlJQV07OkLPRRlJJq6rrBWemIcq2dm8/ye03z19pk4HaEYQo0uMhM6SCWZ/v/8x1vMt4KKMxIpTI9ns4nb8fXNFynNkgQUre5dmM/Zjj7eq4vN+VySgII0koCC7oaVZbG1voWBAOYU9Q0Ocaq1m2mZkoCi1ZpZ2aR4XWz44NS13zwJSQIK0kgCCmYgGvzdsK6+QfY1tE34mBMt3Qxr/ziUiE4el5NPLC3m5f1NQf8MRSNJQEFK9LjITfEG3QJaPi0DpQioGzZS4FC6YNHtj1aW4HY6ePStOqtDiThJQCFQkplIfXNwd6JSE+KYl+/jzUPnJnw7vs5IeiXSBYtqWcke1i8uZNPuBhrbYmvfaElAIVCSFdxcoBEfX1TA3oZ2nth+ckLvrz9/0ZgM6Q762sJan7thGlrDj9+ptzqUiJIEFAKlmYm0dQ9w4WJwBQP/YGkxq8oz+YcXaiZUMaO+uYvSTBn/mQzyU+O5Z2E+Gz44SXOA6wKjmSSgEBgZgwm2G+ZwKL5733zi3U7+fMPuq+62qLWm/rzcgp9M/uTGafQNDvP4lmNWhxIxkoBCoMRohQQ7EA2QneLln9bNo7qxg+/+dvy64i0X+2nvGZA7YJNIaVYSayum8F/vn6C9Z8DqcCJCElAIFKTF43KokN1GvXVOLp9YWsSP36nnvXE2HBtJdtICmlwevrGMzr5B/uv941aHEhGSgELA7XRQnJHAkbOhW5P113fOoiQzkS8/tZe27ivHlkZuwU+TMaBJZXZeCmtmZvMfW47R3T/5t2yVBBQiC4vS2HmiNWSbgyXEufj++oW0XOzj65v2X3Frvr75InEuB/lp8SG5nrCPh1eXcaF7gCe2TexuaDSTBBQiS0vSudA9wNEQrkyfm+/jf906g5cPnOHpnQ0feq3+fBclGYkxuYBxsltUnMay0nQe21xP36BtN4IICUlAIbKsNAMIrkrGWD63qpTrSjP4u19Xc3zUGJPcAZvcvri6nLMdfWzcObm36pAEFCIFafHk+bxsqzdfJWMsDofiu/fPx+108Oe/2sPA0DADQ8OcbO2WBDSJrSjLYH5hKo++XWe66EE0kAQUIkoplpZmsO1YS8A7G15LXmo8/3hPBXtPtfH9149ysrWbwWEtkxAnMaUUD984jZOt3bywr8nqcMJGElAILS1Jp7mr/9IarVC6c94U7ltUwA/erOVXxtYN0gKa3G6elcOMnGR++FZtyH+p2YUkoBAKRbXUq/nbj82hMD3h0nohmYQ4uTkcis/fUMqRs128fcSa0lPhJgkohEoyE8lK9oR8HGhEksfF9x5YgNOhyEyKwxcvi1Anu4/MyyMnxcNPNk/O5RlW1oZPV0r9Vil11PgzzXh+qlKqRym1x/h6NNgPGSlKKZaWpIdlHGjEwqI0vn1PBZ+/flpYzi/sJc7l4NPLS9hS20xN4+SrnmFlbfivAa9rrcuB143vR9RprRcYXw9N7KPYw9LSDM529HGipTts17h/cSGfvb40bOcX9vKJJUUkxDn5yZbJt1WHZbXh8SevnxuPfw7cHVDkNrUszONAIvb4EtzcX1XIb/Y2TrpSzlbWhs/RWjcBGH9mj3qtRCm12zjvqnFisrw2/FjKspPISIwL2ziQiE2fWVHC0LDmZ+8dtzqUkLJjbfgmoEhrvRD4MvCEUipljJgsrw0/FqUUi4rT2BPA5vJCXEtRRgK3zcnll1tPcLFv8ixStbI2/Fml1BQA489zxjX6tNYtxuOdQB3+1lbUyEnx0hrk7ohCXO6PV5XS0TvIM5etC4xmVtaG/zXwKePxp4DnR13PaTwuxV8bPqpG31IT3LT3DIRsZbwQ4F+kWlmUyn9sOcbQJPnZsqw2PPAd4Bal1FHgFuN7gOuBfUqpvcAzwENa66gaUElNiENr6OydPE1lYQ+fXVXKydZuXqs+Y3UoIWFlbfgW4KYxnt8IbLxWXHaWakwQvNDdjy9BJguK0Ll1Ti5F6Qk8trmeOyqmWB1O0GQmdBikGkmnLUb29RWR43Qo/mhlCbtOtrHzRFR1DMYkCSgMUhPiAMbcSlWIYN1XVYAv3s1j70T/8gxJQGFwqQXULS0gEXoJcS7+cFkxr9ac+dAmddFIElAYpEkLSITZ/1hejNvh4D+ivIaYJKAwSPH6x/ZlDEiES3ayl7sX5vH0zlNRPedMElAYuJwOkr0u6YKJsPrjVaX0Dgzzi60nrA7FNElAYZKWECddMBFW03OSWT0ji/98/zi9A9FZPUMSUJikJrilCybC7rPXl9Lc1c9zu6OzeoYkoDDxxbu5IF0wEWbXlWYwNz+FxzbXR+XSH0lAYZKWEEe7dMFEmCml+OyqUurOX+TNw2NuyWVrkoDCRLpgIlLWVkwhz+e9VKwgmkgCCpPUeP+K+MmyalnYl9vp4DMrS9h2rJV9UbYPlSSgMPn9inhpBYnwe2BxIckeFz+KslaQJKAwkeUYIpKSvW4+eV0xL+1vovZcp9XhTJgkoDAZSUAXZCBaRMhnV5US73byyBu1VocyYZKAwuTSingZiBYRkp4Yxx8uK+bXexupP9917QNsQBJQmIxsSiazoUUkffb6UuJcDh55MzpaQZKAwuT3K+KlBSQiJzPJwyeXFvP8nsao2KpDElCYpMTLILSwxuduKMXlUPwgClpBtqsNb7z2daVUrXHu24L5gFZxOhQpXpd0wUTEZSd7+cTSIjbtPs2p1vCVCA8F29WGV0rNBtYDc4zjfjhSpifapCfGca6zz+owRAx66IZpOKOgFWTH2vB3ARuMAoXHgFpgyYQ+jc1UFqXxfn2LzIYWEZeT4uXBxYU8s7OBhgv2bQXZsTZ8PnBq1PsajOcuj8mWteFHu2lWDm3dA+w+ecHqUEQMeujGaTiU4kdv23d2tB1rw491jiuaEHatDT/aqumZuByK1w9F3yplEf2m+OJZW5HLr/c2MjA0bHU4Y7JdbXjjvIWj3lcANAYSp12keN0sKUnn9YNnrQ5FxKg75+XR3jPAu7WBVE2PHNvVhjeeX6+U8iilSvDXht8ewHltZc3MbI6c7bL93QgxOa0qzyTJ4+Kl/U1WhzIm29WG11pXA08BNcArwMNa6+jc8Bb/OBDAG9INExbwup3cPCub12rO2rIbZrva8MZr3wK+da3YokFJZiKlWYm8fugcn1o+1epwRAy6c14ez+1p5L26Fm6Ybq/xUpkJHQE3zcxma10LF/sGrQ5FxKBL3bB99uuGSQKKgDUzc+gfGmbzUXsOBIrJbaQb9mrNGdt1wyQBRUDV1DSSvS7eOCR3w4Q11lZMoa17gPfqWqwO5UMkAUWA2+ngxhnZvHHofFSWThHR7/rpWbbshkkCipCbZmbT3NXH/tPtVociYpDX7eQmG3bDJAFFyA3Ts3AoZFa0sMydRjfsfRt1wyQBRUhaYhyLitNkVrSwzKVumI0mJUoCiqA1M3OobuzgTHuv1aGIGHSpG1Ztn26YJKAIunmWf8G/zIoWVllbMYUL3QNsrbdHN0wSUASVZSdRmB4vt+OFZW6YnkVinJMXbXI3TBJQBCmluGlmDltqm+kdiNrlbSKK+bthObbphkkCirA1M7PpHRi21Z0IEVvunGefbpgkoAhbWppOYpyT38ndMGGRkW6YHe6GSQKKMI/LyaryLN44dE5mRQtLjHTDXjlwhr5Ba4cCJAFZ4I6KXJrae23RBBax6f6qQi50D/DUB6eu/eYwkgRkgdvm5JLidfGrHdb+44vYtaIsg8VT03jkzVpLb4hIArKA1+3k7oX5vHzgDO1SOVVYQCnFl26ZztmOPp7cftKyOCQBWeT+qkL6B4d5fu9pq0MRMWr5tEyWlabzgzfr6Om3phUkCcgic/N9zM1PYcN26YYJ63z5lhk0d/Xxi60nLLl+JGrD3268p1Yp9bVRz89XSr2vlNqvlPqNUirFeH6qUqpHKbXH+Ho0FB/Ujh6oKqSmqYMDskWHsMiSknRWlWfy6Nt1lmwZHNba8EZN9x8AdwCzgQeN2u8APwG+prWuAJ7FX9xwRJ3WeoHx9ZDJz2Z7H1uQj8fl4FcW34kQse0vbp5Oy8V+/vP9yLeCwl0bfglQq7WuN6pobMCftABmAO8Yj38LrDP9KaKUL97NHXNzeW7PaVmaISyzqDiNG2dk8aN36ujsjexNkXDXhr9anfcDwMeMx/fx4WqoJUqp3cZ5V40Tk+1rw0/EA4uL6Owd5OUD1s9KFbHrSzdPp617gJ+9ezyi1w13bfir1Xn/DPCwUmonkAz0G883AUVa64XAl4EnRsaHLovJ9rXhJ2JZaTrFGQnSDROWml+Yys2zcnhscz3tPZFrBYW7Nvy4dd611oe01rdqrRcBTwJ1xvN9RtFCtNY7jeenB/axoodSivurCtla38rx5otWhyNi2F/cXE5H7yCPbzkWsWuGuzb8B0C5UqpEKRUHrMdf+x2lVLbxpwP4a+DRUddzGo9L8deGrw/mQ9rdusoCHAqekpnRwkJz833cPieXx7cco627/9oHhEBYa8NrrQeBLwKvAgeBp4za7+C/I3YEfzJrBH5qPH89sE8ptRd4BnhIa90aig9rV7k+L6tnZPPMzgYGbbBHi4hdf3FLOZ19gzy2OTK/85XW0b8iu6qqSu/YscPqMILyavUZPv9fO/nppxezema21eGIGPbwE7t489A5tnx1DemJcUGfTym1U2tdNdZrMhPaJm6Y7h9Ir2nqsDgSEeu+dHM5PQND/OidurBfSxKQTXjdTnzxbs52SMUMYa2y7GTump/Hf753gvOdfWG9liQgG8lJ8UgCErbwZzeV0zc4xKNvh7cVJAnIRrKTvZwL828cISaiNCuJexYW8IutJ8L6S1ESkI1kp3g41yEJSNjDn99UzuCw5t/fCl8rSBKQjeSkeDnX2St7RQtbKMpI4L5FBTyx7SRN7T1huYYkIBvJSfYwMKRpjdAkMCGu5eHVZWg0P3izNiznlwRkIzkpXgAZiBa2UZiewP1Vhfzqg1M0XOgO+fklAdlItpGAmtokAQn7eHh1GQrFI2+EvhUkCchGZuYmkxjn5JXqM1aHIsQleanxfGJpEU/vbOBES2gXTEsCspFEj4u7Fubzm72NUi1D2Mqf3DgNl0Px/0PcCpIEZDOfWFJE3+Awm3Y3WB2KEJfkpHj55LJiNu1qoP5817UPmCBJQDYzN9/H/MJUnth2ksmwUFhMHg/dMI04l4Pvv340ZOeUBGRDf7CkiKPnuvjg+AWrQxHikqxkD5+6birP722k9lxnSM4pCciGPjJ/CsleF09ss6ZWkxDj+fwN00hwO/ne70LTCpIEZEMJcS7uXZjPvtPtskGZsJX0xDg+vWIqHxxvDUkFDdmQzKa6+gaJdztxOsba118I61zsG8TpUHjdzgm9/2obkrlCGpkImSSP/NMIe0oM4c+mdMGEEJaxXW1447WvG+8/rJS6LdgPKYSwp4m0pUZqw3cppdzAFqXUy0A8v68N3zdSZme0UbXhb8FfI+wDpdSvtdY1+GvD/6XW+m2l1GfwFzf8G6N2/HpgDpAH/E4pNV1rLbWLhZhk7Fgb/i5gg1Gg8BhQa5xHCDHJ2LE2/NWOGR3TpKgNL0Qss2Nt+KsdMzqmSVEbXohYFtD9NK11m1LqLS6rDQ9sV0qN1IYf3Ry5am144Fa4VNr5zmsdI4SYXGxXG954fb1SyqOUKsFfG367+Y8ohLCribSApgA/N+5oOfDXd3/BSCiPG7Xh+xlVGx74idZ6rdZ6UCk1UhveCTx+WW34h43HmzBqw2utq5VSTwE1wCDw8LXugO3cubNZKRWqhVOZXJlI7S4aY4bojFtiDlzxeC9MiqUYoaSU2jHetHG7isaYITrjlphDS2ZCCyEsIwlICGEZSUBX+rHVAZgQjTFDdMYtMYeQjAEJISwjLSAhhGUkAQkhLBMzu14ppX6FfwEsQCrQprVeoJSaChwEDhuvbdVaPxTq4+0U86jXi/DPt/o7rfW/2DlmpdQSfj+WoYyYn7V5zLcA38E/Sbcf+IrW+o1QxBzmuDOAZ4DFwM+01l8MVcyXi5kEpLV+YOSxUuq7QPuol+tG/8cMx/FmhDlmgH8DXg4+0glfM5iYDwBVxuTWKcBepdRvtNaDNo65Gfio1rrRWD/5KmMsrLZh3L3A3wBzja+wiZkENMJYMHs/xjKSSB9vxTXHOl4pdTdQD4S21u5VrhnM8Vrr7lEvexljgXKwwhDz7lEvVwNepZRnZAubUAlD3Bfx7/tVFrIgxxGLY0CrgLNa69F1RUqUUruNbUVWhfl4M0Ias1IqEfgq8PdXPSo4If97VkotVUpVA/uBh0LR+gl3zKOsA3aHOvlc5bqhijusJlULSCn1OyB3jJe+obV+3nj8IPDkqNeagCKtdYtSahHwnFJqjta6Y5zLBHu8HWL+e+DfjF0uJxKmHWLG2IdqjlJqFv71iS9rrXvtHLNx7TnAP2Hs/hAIK+OOCK11zHzhT7hngYKrvOct/GMNIT/eLjEDm4Hjxlcb0Ap80c4xj/GeN+3+92w8XwAcAVaEKtZI/V0DnwYeCUfcI1+TqgU0ATcDh7TWDSNPKKWygFat9ZBSqhT/9h/1YTreFjFrrS81yZVSfwd0aa0fsXPMyr81yyntH4Quxn/35rjNY04FXgS+rrV+N4SxhjXuSIq1MaD1XNnUvB7Yp5Tai//W40Na61YApdRPlFJVZo+3cczhFo6YV+K/87UHeBb4gtY6lFtMhCPmLwJl+Ist7DG+rijeYMO4UUodB/4V+LRSqkH5i0WEnCzFEEJYJtZaQEIIG5EEJISwjCQgIYRlJAEJISwjCUgIYRlJQEIIy0gCEkJY5r8Bxo3f7KzKPOcAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "if not roi_coast.empty:\n",
+    "    roi_coast.plot()\n",
+    "else:\n",
+    "    print(\"ERROR.\\nThe bounding box provided did not intersect with the coastline vector provided.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8e53fe3-5c0b-44b0-87e2-039d74382658",
+   "metadata": {},
+   "source": [
+    "### Add the coastline vector within the bounding box to the map"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "a29bb9c1-cd7c-4b25-801a-4a673f46f9e4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6e36cf6ae2974ca2a8db27e1cb111e3e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(bottom=411668.0, center=[36.10917188776314, -75.62068420217034], controls=(ZoomControl(options=['position'…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "vector_within_bounding_box_json=roi_coast.to_json()\n",
+    "# to_json generates a string that is json format\n",
+    "res = json.loads(vector_within_bounding_box_json)\n",
+    "geo_json_vector = GeoJSON(\n",
+    "    data=res,\n",
+    "    style={\n",
+    "        'color':'yellow','fill_color':'yellow' ,'opacity': 1, 'dashArray': '5', 'fillOpacity': 0.5, 'weight': 4\n",
+    "    },\n",
+    "    hover_style={\n",
+    "        'color': 'white', 'dashArray': '4', 'fillOpacity': 0.7\n",
+    "    },\n",
+    ")\n",
+    "m.add_layer(geo_json_vector)\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "189db20f-4c49-4ff5-9a08-46f2944f4104",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Generate Polygons along the selected portion of the coastline vector\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a121e3c-c98a-4a54-8d55-9ddf97ddc617",
+   "metadata": {},
+   "source": [
+    "### Convert the clipped portion of the coastline into geojson"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "3fafdf4e-5154-499e-b548-635fa1668f14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# vector_within_bounding_box_geojson\n",
+    "vector_within_bounding_box_geojson = json.loads(vector_within_bounding_box_json)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "f758f305-553d-487f-8c1e-49af95cb0ee4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "There are 1 feature(s) in the bounding box\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"There are {len(vector_within_bounding_box_geojson['features'])} feature(s) in the bounding box\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d351288-391c-4f09-bbff-2a95f91d2235",
+   "metadata": {},
+   "source": [
+    "# Convert the geometry of coastline within the bounding box to a list of linestrings\n",
+    "For each of the linestrings and the linestrings within the multilinestring coastline that make up the coastline vector add them to the list of linestrings. These linestrings will have pointers interpolated along them later"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "eb634e77-6243-4ce8-84cd-43f373b1dbb2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_linestring_list(vector_within_bounding_box_geojson:dict)->list:\n",
+    "    \"\"\"\n",
+    "    Create a list of linestrings from the multilinestrings and linestrings that compose the vector\n",
+    "\n",
+    "    Arguments:\n",
+    "    -----------\n",
+    "    vector_within_bounding_box_geojson: dict\n",
+    "        geojson vector \n",
+    "    Returns:\n",
+    "    -----------\n",
+    "    lines_list: list\n",
+    "        list of multiple shapely.geometry.linestring.LineString that represent each segment of the vector\n",
+    "    \"\"\"\n",
+    "    lines_list=[]\n",
+    "    length_vector_bbox_features=len(vector_within_bounding_box_geojson['features'])\n",
+    "    length_vector_bbox_features\n",
+    "\n",
+    "    if(length_vector_bbox_features != 1):\n",
+    "        for i in range(0,length_vector_bbox_features):\n",
+    "            if  vector_within_bounding_box_geojson['features'][i]['geometry']['type'] == 'MultiLineString':\n",
+    "                for y in range(len(vector_within_bounding_box_geojson['features'][i]['geometry']['coordinates'])):\n",
+    "                    line=LineString(vector_within_bounding_box_geojson['features'][i]['geometry']['coordinates'][y])\n",
+    "                    lines_list.append(line)\n",
+    "            elif  vector_within_bounding_box_geojson['features'][i]['geometry']['type'] == 'LineString':\n",
+    "                line=LineString(vector_within_bounding_box_geojson['features'][i]['geometry']['coordinates'])\n",
+    "                lines_list.append(line)\n",
+    "    else:\n",
+    "        for i in range(0,len(vector_within_bounding_box_geojson['features'])):\n",
+    "            if  vector_within_bounding_box_geojson['features'][0]['geometry']['type'] == 'MultiLineString':\n",
+    "                for y in range(len(vector_within_bounding_box_geojson['features'][0]['geometry']['coordinates'])):\n",
+    "                    line=LineString(vector_within_bounding_box_geojson['features'][0]['geometry']['coordinates'][y])\n",
+    "                    lines_list.append(line)\n",
+    "            elif  vector_within_bounding_box_geojson['features'][i]['geometry']['type'] == 'LineString':\n",
+    "                line=LineString(vector_within_bounding_box_geojson['features'][i]['geometry']['coordinates'])\n",
+    "                lines_list.append(line)\n",
+    "    return lines_list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "e00713a4-e583-4e01-9b58-acd0801e1b9c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lines_list=create_linestring_list(vector_within_bounding_box_geojson)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "63cc8bc2-12fe-4017-b0a4-d074adc89cc4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The number of linestring(s) in lines_list: 3\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"The number of linestring(s) in lines_list: {len(lines_list)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6c6790b7-3cd0-48c1-975e-e47f55ee8037",
+   "metadata": {},
+   "source": [
+    "## Interpolate Equal Distances Between Each Point on the Vector\n",
+    "For each LineString that makes up the coastline :\n",
+    "1. Calculate the distance between each point so that they are equally spaced\n",
+    "2. Create a tuple of each of the equally spaced distance points\n",
+    "3. Check if the linestring is closed and if it is then choose the 1st coordinate as the boundary\n",
+    "4. Interpolate the linestring for each of the distances points calculated earlier\n",
+    "5. Add the new multipoint generated by the interpolation to multipoint_list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "1475427a-5276-4acf-96ec-02c1564798be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def interpolate_points(lines_list:list,num_pts=10)->list:\n",
+    "    \"\"\"\n",
+    "    Create a list of multipoints for the interpolated points along each line in the lines_list\n",
+    "\n",
+    "    Arguments:\n",
+    "    -----------\n",
+    "    lines_list: list\n",
+    "        list of multiple shapely.geometry.linestring.LineString that represent each segment of the vector\n",
+    "    \n",
+    "    num_pts: int\n",
+    "        integer value representing the number of interpolated points created per LineString\n",
+    "        \n",
+    "    Returns:\n",
+    "    -----------\n",
+    "    multipoint_list: list\n",
+    "    A list of multiple shapely.geometry.multipoint.MultiPoint \n",
+    "    \"\"\"\n",
+    "    # multipoint_list holds the multipoint for each feature of the coastline within the bbox\n",
+    "    multipoint_list=[]\n",
+    "\n",
+    "    for i in range(len(lines_list)):\n",
+    "        line=lines_list[i]\n",
+    "        distance_delta=line.length/num_pts\n",
+    "        distances = np.arange(0, line.length, distance_delta)\n",
+    "        if lines_list[i].is_closed:\n",
+    "            #Its a closed shape so its boundary points are NULL\n",
+    "            boundary=Point(lines_list[i].coords[0])\n",
+    "        else: \n",
+    "            boundary=lines_list[i].boundary.geoms[0]\n",
+    "        points = [lines_list[i].interpolate(distance) for distance in distances] + [boundary]\n",
+    "        multipoint = unary_union(points) \n",
+    "        multipoint\n",
+    "        multipoint_list.append(multipoint)\n",
+    "    return multipoint_list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "da584533-6ec1-41e5-bf02-cbc2eb92d27c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multipoint_list=interpolate_points(lines_list)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e444648-d22c-4bbd-9185-32af09546234",
+   "metadata": {},
+   "source": [
+    "## Convert the multipoint from the interpolation to a tuple\n",
+    "- ipyleaflet requires that the points be a tuple to be plotted onto the map"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "31b0f358-688f-4a96-814b-d2a19d8160ba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def convert_multipoints_to_tuples(multipoint_list:list)-> list:\n",
+    "    \"\"\"\n",
+    "    Create a list of tuples for the points in multipoint_list\n",
+    "\n",
+    "    Arguments:\n",
+    "    -----------\n",
+    "    multipoint_list: list\n",
+    "        A list of multiple shapely.geometry.multipoint.MultiPoint\n",
+    "    Returns:\n",
+    "    -----------\n",
+    "    points_list_collection: list\n",
+    "        A list of tuples each tuple represents a single point\n",
+    "    \"\"\"\n",
+    "    points_list_collection=[]\n",
+    "    for multipoint in  multipoint_list:\n",
+    "        # First get each point from the multipoint object\n",
+    "        points_array=[point for point in multipoint.geoms]\n",
+    "        # Create an empty array to hold all the points as tuples\n",
+    "        points_list=[]\n",
+    "        # For each point swap lat and lng because ipyleaflet swaps them\n",
+    "        for point in points_array:\n",
+    "            point_tuple=(point.coords[0][1],point.coords[0][0])\n",
+    "            points_list.append(point_tuple)\n",
+    "\n",
+    "        points_list_collection.append(points_list)\n",
+    "    return points_list_collection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "41b71de8-7d2a-4c4b-b83a-568a14a8c130",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "points_list_collection=convert_multipoints_to_tuples(multipoint_list)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b2e1e3f-7178-422b-ba78-bba651ede181",
+   "metadata": {},
+   "source": [
+    "## Function to Convert ipyleaflet Polygon Points to GeoJson\n",
+    "1. Ipyleaflet draws its shapes in lat,lng format and it must be converted to lng, lat for geojson.\n",
+    "2. In order to correctly draw a rectangle in geojson the order of the points matters as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "10788b9c-0da1-44f4-b33b-9cb641204820",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def convert_to_geojson(upper_right_y : float, upper_right_x: float,upper_left_y: float, upper_left_x: float,lower_left_y: float,  lower_left_x: float,lower_right_y: float,lower_right_x: float) -> dict:\n",
+    "    \"\"\"Convert the 4 corners of the rectangle into geojson  \"\"\"\n",
+    "    geojson_feature={}\n",
+    "    geojson_feature[\"type\"]=\"Feature\"\n",
+    "    geojson_feature[\"properties\"]={}\n",
+    "    geojson_feature[\"geometry\"]={}\n",
+    "    \n",
+    "    geojson_polygon={}\n",
+    "    geojson_polygon[\"type\"]=\"Polygon\"\n",
+    "    geojson_polygon[\"coordinates\"]=[]\n",
+    "#     The coordinates(which are 1,2 arrays) are nested within a parent array\n",
+    "    nested_array=[]\n",
+    "    nested_array.append([upper_right_x, upper_right_y])\n",
+    "    nested_array.append([upper_left_x, upper_left_y])\n",
+    "    nested_array.append([lower_left_x, lower_left_y])\n",
+    "    nested_array.append([lower_right_x, lower_right_y])\n",
+    "    #GeoJson rectangles have the first point repeated again as the last point\n",
+    "    nested_array.append([upper_right_x, upper_right_y])\n",
+    "\n",
+    "    geojson_polygon[\"coordinates\"].append(nested_array)\n",
+    "    \n",
+    "    geojson_feature[\"geometry\"]=geojson_polygon\n",
+    "    return geojson_feature"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b069b6e4-5b92-4435-b8a3-6da8a4afcded",
+   "metadata": {},
+   "source": [
+    "## Function to Write Polygons in GeoJson to a .geojson file\n",
+    "1. Pass the filename and the geojson from ***convert_to_geojson()***"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "f98e2c2a-e103-4d0a-8597-43d3408212af",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def write_to_geojson_file(filename : str,geojson_polygons : dict):\n",
+    "    \"\"\"Make a filename.geojson file from dictionary geojson_polygons  \"\"\"\n",
+    "    features = []\n",
+    "    count=0\n",
+    "    for geoObj in geojson_polygons[\"features\"]:\n",
+    "        features.append(Feature(properties={\"id\":count },geometry=geoObj[\"geometry\"]))\n",
+    "        count=count+1\n",
+    "\n",
+    "    feature_collection = FeatureCollection(features)\n",
+    "\n",
+    "    with open(f'{filename}', 'w') as f:\n",
+    "        dump(feature_collection, f)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d525b5c-5396-49f2-89ef-be34d9b8939c",
+   "metadata": {},
+   "source": [
+    "## Create a Rectangle For Each Interpolated Point on the Vector\n",
+    "1. Create a list to hold all the polygons to be added on to the map\n",
+    "2. Convert each of the rectangles to geojson for further analysis later using ***convert_to_geojson()***"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "458a403b-4eec-4f2e-8977-d2170200e764",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_reactangles(points_list_collection: list)-> dict:\n",
+    "    \"\"\"\n",
+    "    Create the geojson rectangles for each point in the points_list_collection\n",
+    "\n",
+    "    Arguments:\n",
+    "    -----------\n",
+    "    points_list_collection: list\n",
+    "        list of tuples containing all the interpolated points along the given vector\n",
+    "\n",
+    "    Returns:\n",
+    "    -----------\n",
+    "    geojson_polygons: dict\n",
+    "       geojson dictionary contains all the rectangles generated\n",
+    "    \"\"\"\n",
+    "    size=0.002                                         \n",
+    "    geojson_polygons={\"type\": \"FeatureCollection\",\"features\":[]}\n",
+    "\n",
+    "    # Create a rectangle at each point on the line\n",
+    "    # Swap the x and y for each point because ipyleaflet swaps them for draw methods\n",
+    "    for points_list in points_list_collection:\n",
+    "        for point in points_list:\n",
+    "            upper_right_x=point[0]-(size/2)\n",
+    "            upper_right_y=point[1]-(size/2)\n",
+    "            upper_left_x=point[0]+(size/2)\n",
+    "            upper_left_y=point[1]-(size/2)\n",
+    "            lower_left_x=point[0]+(size/2)\n",
+    "            lower_left_y=point[1]+(size/2)\n",
+    "            lower_right_x=point[0]-(size/2)\n",
+    "            lower_right_y=point[1]+(size/2)\n",
+    "            #Convert each set of points to geojson (DONT swap x and y this time)\n",
+    "            geojson_polygon=convert_to_geojson(upper_right_x, upper_right_y,upper_left_x, upper_left_y,lower_left_x,lower_left_y,lower_right_x,lower_right_y)\n",
+    "            geojson_polygons[\"features\"].append(geojson_polygon)\n",
+    "    return geojson_polygons"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49b1aa81-474b-49d8-b85b-24737f8cc24f",
+   "metadata": {},
+   "source": [
+    "### Create the ROIs along the coastline and write their data to roi.geojson"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "bf8c8ab6-e447-4b57-8339-9428d312e0e8",
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "geojson_polygons=create_reactangles(points_list_collection)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "73a16d07-ca64-4c1b-9e3b-38fc7ff0c3fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "write_to_geojson_file(filename,geojson_polygons)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a83d2d90-e172-4215-b7fe-d6b83f48e04d",
+   "metadata": {},
+   "source": [
+    "## Check if all the ROIs overlap with their neighbors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "462be869-bfb8-419f-ab17-89ff425d6121",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def check_shapes_overlap(filename):\n",
+    "    geo_series=gpd.GeoSeries.from_file(filename)\n",
+    "    shapes_overlap=True\n",
+    "    last_index=geo_series.index[-1]\n",
+    "    for index in geo_series.index:\n",
+    "        geo_series_next=geo_series[index]\n",
+    "        for inner_index in geo_series.index:\n",
+    "            if inner_index==last_index and not geo_series_next.overlaps(geo_series[inner_index]) :\n",
+    "                shapes_overlap=False\n",
+    "            if geo_series_next.overlaps(geo_series[inner_index]) and index != inner_index:\n",
+    "                break\n",
+    "    return shapes_overlap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "0102398b-b064-4b96-9097-292857724116",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "num_pts increased to: 40\n",
+      "num_pts increased to: 40\n"
+     ]
+    }
+   ],
+   "source": [
+    "num_pts=20\n",
+    "too_many_ROI=False\n",
+    "all_shapes_overlap=False\n",
+    "# Convert to while loop when test is done\n",
+    "while all_shapes_overlap==False and too_many_ROI==False:\n",
+    "    multipoint_list=interpolate_points(lines_list,num_pts)\n",
+    "    points_list_collection=convert_multipoints_to_tuples(multipoint_list)\n",
+    "    geojson_polygons=create_reactangles(points_list_collection)\n",
+    "    write_to_geojson_file(filename,geojson_polygons)\n",
+    "    all_shapes_overlap=check_shapes_overlap(filename)\n",
+    "    if not all_shapes_overlap:\n",
+    "        if num_pts == 100:\n",
+    "            too_many_ROI=True\n",
+    "        elif num_pts > 100:\n",
+    "            num_pts=100\n",
+    "        else:\n",
+    "            num_pts=num_pts*2\n",
+    "    print(f\"num_pts increased to: {num_pts}\")\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3621db02-a07d-43df-9f9f-6f198077fb55",
+   "metadata": {},
+   "source": [
+    "# Add the Features to the Map\n",
+    "---\n",
+    "### Markers\n",
+    "    1. Each marker has the lat and lng on hover and on click as a popup\n",
+    "### ROI\n",
+    "    1. Each rectangle can be click on to select it for download with data\n",
+    "    2. Click the rectangle again to unselect it"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "16a254e4-f2cf-4534-9e3c-a8dbff6eb099",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6e36cf6ae2974ca2a8db27e1cb111e3e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(bottom=411668.0, center=[36.10917188776314, -75.62068420217034], controls=(ZoomControl(options=['position'…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import copy\n",
+    "from ipyleaflet import LayerGroup\n",
+    "from ipyleaflet import Map, Marker, MarkerCluster\n",
+    "from ipywidgets import HTML\n",
+    "import geojson\n",
+    "\n",
+    "# @TODO    Add Try Except later\n",
+    "# Raise excecption for invalid file type\n",
+    "# Raise exception for invalid file format\n",
+    "    # geojson layer with hover handler\n",
+    "with open(filename) as f:\n",
+    "    data = geojson.load(f)\n",
+    "\n",
+    "#     Add style to each feature in the geojson\n",
+    "for feature in data[\"features\"]:\n",
+    "    feature[\"properties\"][\"style\"] = {\n",
+    "        \"color\": \"grey\",\n",
+    "        \"weight\": 1,\n",
+    "         \"fillColor\": \"grey\",\n",
+    "        \"fillOpacity\": 0.2,\n",
+    "     }\n",
+    "\n",
+    "selected_set = set()\n",
+    "selected_layer = None\n",
+    "\n",
+    "\n",
+    "def convert_selected_set_to_geojson(selected_set):\n",
+    "#     Create a geojson feature collection with no features\n",
+    "    geojson = {\"type\": \"FeatureCollection\", \"features\": []}\n",
+    "# Iterate through all the features in the geojson data and check if its name is in the selected_set\n",
+    "# if its name is then add it as a geojson feature\n",
+    "    geojson[\"features\"] = [\n",
+    "        feature\n",
+    "        for feature in data[\"features\"]\n",
+    "        if feature[\"properties\"][\"id\"] in selected_set\n",
+    "    ]\n",
+    " #     change the style for the selected features\n",
+    "    for feature in data[\"features\"]:\n",
+    "        feature[\"properties\"][\"style\"] = {\n",
+    "            \"color\": \"blue\",\n",
+    "            \"weight\": 2,\n",
+    "             \"fillColor\": \"grey\",\n",
+    "             \"fillOpacity\": 0.2,\n",
+    "          }\n",
+    "    return geojson\n",
+    "\n",
+    "# If  properties is none is means there is no name and thus nothing to add\n",
+    "# Modify this for my version\n",
+    "# This function allows for the feature to be removed from the selected portion if it is clicked again after being selected\n",
+    "def selected_onclick_handler(event=None, id=None, properties=None, **args):\n",
+    "    global selected_layer\n",
+    "    if properties is None:\n",
+    "        return\n",
+    "    cid = properties[\"id\"]\n",
+    "    selected_set.remove(cid)\n",
+    "#     If the selected_layer is included then remove it\n",
+    "    if selected_layer is not None:\n",
+    "         m.remove_layer(selected_layer)\n",
+    "    selected_layer = GeoJSON(\n",
+    "        data=convert_selected_set_to_geojson(selected_set),\n",
+    "        name=\"Selected ROIs\",\n",
+    "        hover_style={\"fillColor\": \"blue\"},\n",
+    "    )\n",
+    "    selected_layer.on_click(selected_onclick_handler)\n",
+    "    m.add_layer(selected_layer)\n",
+    "\n",
+    "    # selected_onclick_handler mirrors this function\n",
+    "def geojson_onclick_handler(event=None, id=None, properties=None, **args):\n",
+    "    print(\"Click Registered\")\n",
+    "    global selected_layer\n",
+    "#     Custom properties associated with geojson\n",
+    "    if properties is None:\n",
+    "           return\n",
+    "    cid = properties[\"id\"]\n",
+    "#     Add the property to the selected_set (unordered, no duplicates, no index)\n",
+    "    selected_set.add(cid)\n",
+    "#     Remove the previously selected layer from map layer\n",
+    "    if selected_layer is not None:\n",
+    "        m.remove_layer(selected_layer)\n",
+    "# Create a new layer from the selected geojson on the map \n",
+    "# call convert_selected_set_to_geojson() to style the selected geojson\n",
+    "    selected_layer = GeoJSON(\n",
+    "        data=convert_selected_set_to_geojson(selected_set),\n",
+    "        name=\"Selected ROIs\",\n",
+    "        hover_style={\"fillColor\": \"blue\"},\n",
+    "    )\n",
+    "# Add a on_click handler to the selected_layer\n",
+    "    selected_layer.on_click(selected_onclick_handler)\n",
+    "# Add the selected layer to the map\n",
+    "    m.add_layer(selected_layer)\n",
+    "\n",
+    "\n",
+    "geojson_layer = GeoJSON(\n",
+    "    data=data, name=\"ROIs\", hover_style={\"fillColor\": \"red\"}\n",
+    "    )\n",
+    "geojson_layer.on_click(geojson_onclick_handler)\n",
+    "m.add_layer(geojson_layer)\n",
+    "m\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6635d87-9432-4cae-a97d-8e9aafa77e60",
+   "metadata": {},
+   "source": [
+    "## Add the Marker cluser to the map"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "8e660922-2fc0-4bdf-af29-4ff1e56d923d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6e36cf6ae2974ca2a8db27e1cb111e3e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(bottom=411668.0, center=[36.10917188776314, -75.62068420217034], controls=(ZoomControl(options=['position'…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from ipyleaflet import LayerGroup\n",
+    "from ipyleaflet import Map, Marker, MarkerCluster\n",
+    "from ipywidgets import HTML\n",
+    "\n",
+    "markers = ()\n",
+    "for points_list in points_list_collection:\n",
+    "    for point in points_list:\n",
+    "        marker = Marker(location=point,draggable=False,title=f\"Location:({point[1]},{point[0]})\")\n",
+    "        message = HTML(value=f\"Location:({point[1]},{point[0]})\")\n",
+    "        marker.popup = message\n",
+    "        markers=markers + (marker,)\n",
+    "\n",
+    "m.add_layer(MarkerCluster(name = \"CoastSat Shoreline Data\",markers = markers,))\n",
+    "\n",
+    "m\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2fdabe3-c37b-44b9-842d-1278583c37d1",
+   "metadata": {},
+   "source": [
+    "# Add the Selected ROIs a Dictionary \n",
+    "---\n",
+    "1. Print the ID's of the selected ROIs\n",
+    "2. Add the selected ROIs to the dictionary, selected_ROI\n",
+    "3. Optionally, print the selected_ROI\n",
+    "4. Download the geojson file of the selected_ROI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "924d7ab5-2467-47f0-a6f8-81ec1ddf6e5f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "set()\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(selected_set)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "952557e9-1223-4d5e-a85c-c3d37f3776bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a dictionary for the selected ROIs and add the user's selected ROIs to it\n",
+    "selected_ROI={}\n",
+    "selected_ROI[\"features\"] = [\n",
+    "        feature\n",
+    "        for feature in data[\"features\"]\n",
+    "        if feature[\"properties\"][\"id\"] in selected_set\n",
+    "    ]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b7d5689-5561-42c8-a9bf-e1d2d28721d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Optional Code: Prints the geosjon info of the selected_roi\n",
+    "# for ROI in selected_ROI[\"features\"]:\n",
+    "#     print(ROI)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9dbb990-2cbb-4564-b7d1-65f4cc6c9278",
+   "metadata": {},
+   "source": [
+    "### Download the Selected ROI(s) to a geojson file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81b48a55-b46b-4183-ad06-8bb66e323c2d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "selected_roi_file=\"selected_roi.geojson\"\n",
+    "write_to_geojson_file(selected_roi_file,selected_ROI)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c712aaf3-429c-4488-824f-782439a74edc",
+   "metadata": {},
+   "source": [
+    "## Download the bounding box's data from CoastSat\n",
+    "---\n",
+    "1. Preview the data available with CoastSat's check_images_available()\n",
+    "2. Download the data availble CoastSat's retrieve_images()\n",
+    "3. View the metadata downloaded with CoastSat's get_metadata()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "726b97f0-b646-41e1-b9c9-c92576dd30b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import numpy as np\n",
+    "import pickle\n",
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "import matplotlib\n",
+    "matplotlib.use('Qt5Agg')\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib import gridspec\n",
+    "plt.ion()\n",
+    "import pandas as pd\n",
+    "from datetime import datetime\n",
+    "from coastsat import SDS_download, SDS_preprocess, SDS_shoreline, SDS_tools, SDS_transects\n",
+    "# NOTE: modify the \"import gda\"l in SDS_download to \"from osgeo import gdal\" to reslove the module not found error"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "de124c1b-3188-4521-a5be-a5d75a37c537",
+   "metadata": {},
+   "source": [
+    "### For each item in selected_ROI\n",
+    "1. Create a coastSatBBOX\n",
+    "2. Set Coast's polygon equal to the coastSatBBOX\n",
+    "3. Set all the necessary CoastSat parameters\n",
+    "4. Check images available for download"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "591390ec-a2bd-4910-a43c-4cdc015b8504",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def check_images_available_selected_ROI(selected_ROI:dict)->list:\n",
+    "    list_of_inputs=[]\n",
+    "    if selected_ROI[\"features\"] != []:\n",
+    "        for ROI in selected_ROI[\"features\"]:\n",
+    "            coastSatBBOX=ROI[\"geometry\"][\"coordinates\"]\n",
+    "            polygon=coastSatBBOX\n",
+    "            # it's recommended to convert the polygon to the smallest rectangle (sides parallel to coordinate axes)       \n",
+    "            polygon = SDS_tools.smallest_rectangle(polygon)\n",
+    "            # date range\n",
+    "            dates = ['2018-12-01', '2019-01-01']\n",
+    "            # satellite missions\n",
+    "            sat_list = ['S2','L7','L8']\n",
+    "            # name of the site\n",
+    "            sitename = 'NARRA'\n",
+    "            # directory where the data will be stored\n",
+    "            filepath = os.path.join(os.getcwd(), 'data')\n",
+    "            # put all the inputs into a dictionnary\n",
+    "            inputs = {'polygon': polygon, 'dates': dates, 'sat_list': sat_list, 'sitename': sitename, 'filepath':filepath}\n",
+    "            # before downloading the images, check how many images are available for your inputs\n",
+    "            SDS_download.check_images_available(inputs)\n",
+    "            list_of_inputs.append(inputs)\n",
+    "    return list_of_inputs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f89a64e1-e250-43a8-be3f-962aa6736164",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "list_of_inputs=check_images_available_selected_ROI(selected_ROI)\n",
+    "list_of_inputs\n",
+    "if list_of_inputs == []:\n",
+    "    print(\"Error: No ROIs were selected. Please click a valid ROI on the map\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2149b77-1906-43d5-ba4a-f78675a0fa25",
+   "metadata": {},
+   "source": [
+    "### Download the Images with CoastSat's retrieve_images()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4c93174-93f1-4353-89fb-998361cf7eb8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for inputs in list_of_inputs:\n",
+    "  # inputs['include_T2'] = True\n",
+    "    metadata = SDS_download.retrieve_images(inputs)  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "125f7215-3ed7-4701-ad31-5ac7b5dac611",
+   "metadata": {},
+   "source": [
+    "## Print the Metadata Downloaded"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7a08afff-2a69-42ff-8fba-17b8f505e4c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for inputs in list_of_inputs:\n",
+    "    metadata = SDS_download.get_metadata(inputs) \n",
+    "    print(metadata)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.12"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {
+     "001d56bdc0bf435396c636185ccd9446": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "(C) OpenStreetMap contributors, vizualization CC-By-SA 2.0 Freemap.sk",
+       "max_native_zoom": 18,
+       "max_zoom": 16,
+       "min_native_zoom": 0,
+       "name": "FreeMapSK",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://a.freemap.sk/T/{z}/{x}/{y}.jpeg"
+      }
+     },
+     "005b2bae1b4d4ec78e9b41815f9b8177": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_ab51aeef0bc840b79de5ea5c7515f477",
+       "style": "IPY_MODEL_7cf14672f3404aefab86b71fcfaa19e9",
+       "value": "Location:(-75.74262663596114,36.09194000192228)"
+      }
+     },
+     "0076ec681ec04968b826fa45867081e4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5f4489fa22b447cd86bd6d8f7393e285",
+       "style": "IPY_MODEL_e5f690c0047e4226ac48c23bc5f2ead5",
+       "value": "Location:(-75.70687218524027,36.09365675949925)"
+      }
+     },
+     "00a24368d629497e9c4ae8807fc4794b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "00af53b29e414186b4167fd097c51917": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "018dcdfa31c44941b5bd3a7274e00594": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a67f3a2239934bb480163454abcbac86",
+       "style": "IPY_MODEL_08bcd3f14ef04a199f035694f4e140da",
+       "value": "Location:(-75.74345433291064,36.10961522873192)"
+      }
+     },
+     "01bbf70de21f49bda35f0eca3f62ce35": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.107122203288064,
+        -75.74674681131582
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_6e0aea67add34c2bbe606ceae0c1f704",
+       "title": "Location:(-75.74674681131582,36.107122203288064)"
+      }
+     },
+     "02a0ffec18f142198f3a8d32b58aa890": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_8d722b0b7ed74aa482bd47df7bb6d95b",
+       "style": "IPY_MODEL_c01eb5edfb4a47659c9fcd21062d09a7",
+       "value": "Location:(-75.70928943833887,36.09804629453726)"
+      }
+     },
+     "02d4bbc8642749a69b1b46de221069a5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "03842fcea5c4401b97c150e9a36a1885": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ToggleButtonModel",
+      "state": {
+       "button_style": "primary",
+       "icon": "spinner",
+       "layout": "IPY_MODEL_fa5418b5aa51448399b334631a012bf2",
+       "style": "IPY_MODEL_adebc26e4185465b83d37aec5992a4b5",
+       "tooltip": "This is a placeholder"
+      }
+     },
+     "03909292690d495696f0596bfb5fac70": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "03a64e10fd3a4c62b81b4684804987d8": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "(C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "OpenStreetMap.CH",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://tile.osm.ch/switzerland/{z}/{x}/{y}.png"
+      }
+     },
+     "03cae58267b441fe82977b30138319fa": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0400b01a3ee44f4fb13d77c0a0427b95": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "openAIP Data (CC-BY-NC-SA)",
+       "max_native_zoom": 18,
+       "max_zoom": 14,
+       "min_native_zoom": 0,
+       "name": "OpenAIP",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://1.tile.maps.openaip.net/geowebcache/service/tms/1.0.0/openaip_basemap@EPSG%3A900913@png/{z}/{x}/{y}.png"
+      }
+     },
+     "058ff6d6a2d24672a416565883c19f34": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "05f062534a1b4358b105439a0687a7e9": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.10678427557642,
+        -75.74181562010726
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_2856a83a9aa94ad4929c2562724f2251",
+       "title": "Location:(-75.74181562010726,36.10678427557642)"
+      }
+     },
+     "06a8c24376204a6a910b8addf81a05ec": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.10622622282646,
+        -75.74648203893831
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_a938f87e06b34d648c9ab4f3c553fa65",
+       "title": "Location:(-75.74648203893831,36.10622622282646)"
+      }
+     },
+     "076be8162c6c42d48191ee18fd7d6b80": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMapStyleModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "cursor": "move"
+      }
+     },
+     "083b72344af3429ea796fefbd13ac9a5": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.11206192026365,
+        -75.71710320460038
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_d96726e9ea2f4803939dfc03e9bd58c4",
+       "title": "Location:(-75.71710320460038,36.11206192026365)"
+      }
+     },
+     "08bcd3f14ef04a199f035694f4e140da": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "08d1aa4b59164dd49baf15d821c2a983": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.09711649496446,
+        -75.70890657969125
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_e91e50ba5dbe478bb9bfddeaa4b50894",
+       "title": "Location:(-75.70890657969125,36.09711649496446)"
+      }
+     },
+     "08e921f393e94e4fb022596b0129407e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "091e75f9eb734ceaa3735ae7939d6ab6": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.09629621288948,
+        -75.7441579317614
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_a831ea1113ed4d40a27f9cc57edc8138",
+       "title": "Location:(-75.7441579317614,36.09629621288948)"
+      }
+     },
+     "09c22a2918bc47e7934672c33e89561c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0ae788ea164b40f794a9078add6dcd5f": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map tiles by Stamen Design, CC BY 3.0 -- Map data (C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "Stamen.TonerLite",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://stamen-tiles-a.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png"
+      }
+     },
+     "0b1ef54d05024fcf9c15e11abb7c20f5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0bfae8a58ccd4adc9c5093c4187612e2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_00a24368d629497e9c4ae8807fc4794b",
+       "style": "IPY_MODEL_b9c0c6d7bdd24ee49e434e312771df44",
+       "value": "Location:(-75.72041263658134,36.118249816820814)"
+      }
+     },
+     "0c3dc035990544eda0c5bf70c100a5b1": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0c92371398de41f4be1f41bc2862eea9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0ce7e102fee44270a6ff7b75dc2ba237": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0df931799d5342fa997ae2aeb25e4d66": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.12532206749744,
+        -75.7438718306166
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_5e37a4c1fbb74d65bcc76f358b675264",
+       "title": "Location:(-75.7438718306166,36.12532206749744)"
+      }
+     },
+     "0e3f262c70ca4a8ba450d9c6a80b289a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0e6462ca2127411b891d4ceb62e39991": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "0e971e22ea98429b8a02c8ec8c8cd379": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "height": "auto",
+       "padding": "0px 0px 0px 4px",
+       "width": "auto"
+      }
+     },
+     "0eb25bb888ed492eb006ec0d1d465c15": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "0f424589c3f04f6094a9bdae1adfbcc6": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "(C) OpenStreetMap contributors (C) CARTO",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "CartoDB.PositronOnlyLabels",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://a.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}.png"
+      }
+     },
+     "0f935e62c7c44d2a872f25c3eb3d1cbc": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Tiles (C) Esri -- Source: USGS, Esri, TANA, DeLorme, and NPS",
+       "max_native_zoom": 18,
+       "max_zoom": 13,
+       "min_native_zoom": 0,
+       "name": "Esri.WorldTerrain",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Terrain_Base/MapServer/tile/{z}/{y}/{x}"
+      }
+     },
+     "10bb4bf4025e4cd1b0ad20a17f0b636e": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.114834326159816,
+        -75.74535414903995
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_90d53be96e73442b88a3d92046245743",
+       "title": "Location:(-75.74535414903995,36.114834326159816)"
+      }
+     },
+     "11c063779af44a5b83c26f09822b246a": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.091954919833086,
+        -75.70580065656158
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_f8b231a062d8483b82ac207ce8536586",
+       "title": "Location:(-75.70580065656158,36.091954919833086)"
+      }
+     },
+     "12b5a6ef1f9144c999ee14501ecd1b0b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "13034da10d5f40289b4fc6de85c27067": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Tiles (C) Esri -- Source: Esri",
+       "max_native_zoom": 18,
+       "max_zoom": 13,
+       "min_native_zoom": 0,
+       "name": "Esri.WorldShadedRelief",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Shaded_Relief/MapServer/tile/{z}/{y}/{x}"
+      }
+     },
+     "13fc414c5605426dadcac69862bee518": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ToggleButtonModel",
+      "state": {
+       "button_style": "primary",
+       "icon": "eraser",
+       "layout": "IPY_MODEL_a032933ad99c4b6a9ed0af9dfa01a91d",
+       "style": "IPY_MODEL_4c21002c5baf4f8a8655ffb82b6bfa44",
+       "tooltip": "Remove all drawn features"
+      }
+     },
+     "140e09f37c2d45ac90220e3331e43805": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_cca4015673514a1f856fbf172d1de565",
+       "style": "IPY_MODEL_caffcea9f39243919ac7559acbcd0308",
+       "value": "Location:(-75.74259628368763,36.11785652929547)"
+      }
+     },
+     "14914602f334433b99cc532908951c99": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_f13ecefd1ba64dd390890c383cc8e372",
+       "style": "IPY_MODEL_df14ca0bc797476286e4e423abff782b",
+       "value": "Location:(-75.74334900263659,36.09461094444164)"
+      }
+     },
+     "1578d68f015f4618a35f753559fb7628": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "160a15dcb6a9455a9a8d542bc81ebd8f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "161b1fc565594823b4ae7ef6d3b1c5b2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a57108d6b2f94565a6004222753c9013",
+       "style": "IPY_MODEL_b1594fe294674102a3398cbf312c3515",
+       "value": "Location:(-75.74834546903386,36.11345692573785)"
+      }
+     },
+     "16378d9bb114409eace7e3ba04bdfe87": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map tiles by Stamen Design, CC BY 3.0 -- Map data (C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "Stamen.TopOSMRelief",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://stamen-tiles-a.a.ssl.fastly.net/toposm-color-relief/{z}/{x}/{y}.jpg"
+      }
+     },
+     "165f79c2c0d24993856bb56b9036203f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "166c030555e74895a6b4678bda24f2eb": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.10687161447046,
+        -75.71407724635286
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_b30f15deabe14d3e9648176230557be1",
+       "title": "Location:(-75.71407724635286,36.10687161447046)"
+      }
+     },
+     "166d80b82c1f4f0a804c6cc6fde436ec": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "16cb5cf782b0495aa98514cb48986bb3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "16f0c9c3435440e2a5d565a2bdca83a6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_9c90bf3aebae4daa95af9faeed69fcb7",
+       "style": "IPY_MODEL_17dcf33e41f24f1b8f982d3866fa764b",
+       "value": "Location:(-75.7478130933438,36.1116650796005)"
+      }
+     },
+     "17dcf33e41f24f1b8f982d3866fa764b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "183a2a47e1e1462989d15c8913199aa7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "189642aa7da4411faf7f9e8987478dc9": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletWMSLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "USGS",
+       "crs": {
+        "custom": false,
+        "name": "EPSG3857"
+       },
+       "format": "image/png",
+       "layers": "33DEPElevation:Hillshade Elevation Tinted",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "USGS 3DEP Elevation",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "format",
+        "layers",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "styles",
+        "tile_size",
+        "tms",
+        "transparent",
+        "uppercase"
+       ],
+       "transparent": true,
+       "url": "https://elevation.nationalmap.gov/arcgis/services/3DEPElevation/ImageServer/WMSServer?"
+      }
+     },
+     "18e05b666c554a95836cc31253428256": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_c3160fb37fcf45a0a7770d54b5db7988",
+       "style": "IPY_MODEL_68c4d2ef1fcb4b47b010e893736adf42",
+       "value": "Location:(-75.74592232610013,36.103493758189416)"
+      }
+     },
+     "19c4eff125564ad8a27d3dd4521ab701": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_bea897431f5d405abe6afc9c81736393",
+       "style": "IPY_MODEL_47655f2eb1f94ef2b67f7ef82b93191a",
+       "value": "Location:(-75.7515081808345,36.12217880198888)"
+      }
+     },
+     "1aa3b693c6ce43bdb526089a9eb25519": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.11643895227945,
+        -75.71953793413647
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_d3771faeeb254d578ade29ebcdf2128c",
+       "title": "Location:(-75.71953793413647,36.11643895227945)"
+      }
+     },
+     "1af6b36ae97045fab1defeea35609c7e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_9183a1408c7e4b43af0492d69ac20a47",
+       "style": "IPY_MODEL_71d9f934b30940d0b8d14e34ef4af00c",
+       "value": "Location:(-75.74727096896378,36.10987605829631)"
+      }
+     },
+     "1b571e65933e4ebd9022e7ee21bed689": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "1ba40c1e6b4340e69295c3b708a8c752": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
+       "max_native_zoom": 18,
+       "max_zoom": 8,
+       "min_native_zoom": 0,
+       "name": "NASAGIBS.ModisTerraSnowCover",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/MODIS_Terra_NDSI_Snow_Cover/default//GoogleMapsCompatible_Level8/{z}/{y}/{x}.png"
+      }
+     },
+     "1bab3e7161e948f2aac0e1471da2db55": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "1bad01dcf92246318d0df71d33d0c4ac": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "height": "auto",
+       "padding": "0px 0px 0px 4px",
+       "width": "auto"
+      }
+     },
+     "1baf7ab905d145bcaf61a214cc4c9d60": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.11354215204953,
+        -75.74172411010603
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_4220ea903b6e426899552135d42be328",
+       "title": "Location:(-75.74172411010603,36.11354215204953)"
+      }
+     },
+     "1c76b058d0e045ca8a433bec47922d45": {
+      "model_module": "@here/map-widget-for-jupyter",
+      "model_module_version": "^1.1.3",
+      "model_name": "DefaultLayersModel",
+      "state": {
+       "_model_module": "@here/map-widget-for-jupyter",
+       "_model_module_version": "^1.1.3",
+       "_view_count": null,
+       "_view_module": "@here/map-widget-for-jupyter",
+       "_view_module_version": "^1.1.3",
+       "layer_name": "raster.terrain.labels",
+       "ppi": null
+      }
+     },
+     "1c799939e50447b0a3a42540d4365d89": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.10860172725625,
+        -75.71510249837408
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_f45d084eed4d453da3847dcb75d6abb6",
+       "title": "Location:(-75.71510249837408,36.10860172725625)"
+      }
+     },
+     "1c8a94cd6f98458782f4f7bce9f8e99a": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.112559590252594,
+        -75.74808415553382
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_e84fcdc7593f4f90b1970c51f959b524",
+       "title": "Location:(-75.74808415553382,36.112559590252594)"
+      }
+     },
+     "1c91f90fa21148788f1af90db5462fd2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "1cad066a28cf493db589f82af0c3cb8d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "1cc5bfbfd0f548a78a80e94044505c2f": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "(C) Stadia Maps, (C) OpenMapTiles (C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "Stadia.AlidadeSmoothDark",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://tiles.stadiamaps.com/tiles/alidade_smooth_dark/{z}/{x}/{y}.png"
+      }
+     },
+     "1d19729d0f0f4c428082904f3eb72c92": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "1d33c113c74544618eec5865f81edda7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "1d6064742358428f9aa76450fdc2a513": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Datenquelle: basemap.at",
+       "max_native_zoom": 18,
+       "max_zoom": 19,
+       "min_native_zoom": 0,
+       "name": "BasemapAT.overlay",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://maps.wien.gv.at/basemap/bmapoverlay/normal/google3857/{z}/{y}/{x}.png"
+      }
+     },
+     "1dbaa2f0a9ea4f91b8c46afb7c9b6286": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.11345692573785,
+        -75.74834546903386
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_161b1fc565594823b4ae7ef6d3b1c5b2",
+       "title": "Location:(-75.74834546903386,36.11345692573785)"
+      }
+     },
+     "1ecc83b5eb114945a58e295efde46064": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.11253081219468,
+        -75.74126057933923
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_745f240b66f04b56837e6c083d8ac01f",
+       "title": "Location:(-75.74126057933923,36.11253081219468)"
+      }
+     },
+     "2020cc59927e4fa39f12a9fffb5accad": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "207b3977ec684ff4bbb5d5f4af217032": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2138764edb134477bd96cee08f35f4e7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_2193ce11fe514791bfaacd6fc3f7f1f7",
+       "style": "IPY_MODEL_5876ab0ae5344c659b1cf0e0e6904e7a",
+       "value": "Location:(-75.74670326044347,36.120230771773876)"
+      }
+     },
+     "215fdc6d9f594472b0813e47edb463ad": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Tiles (C) Esri -- Sources: GEBCO, NOAA, CHS, OSU, UNH, CSUMB, National Geographic, DeLorme, NAVTEQ, and Esri",
+       "max_native_zoom": 18,
+       "max_zoom": 13,
+       "min_native_zoom": 0,
+       "name": "Esri.OceanBasemap",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://server.arcgisonline.com/ArcGIS/rest/services/Ocean_Basemap/MapServer/tile/{z}/{y}/{x}"
+      }
+     },
+     "2193ce11fe514791bfaacd6fc3f7f1f7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "21bcd7d9375048079bc0682b3b1ff7bb": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.12451713334178,
+        -75.74788830111393
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_f38a28c19ab949638728c484978b9374",
+       "title": "Location:(-75.74788830111393,36.12451713334178)"
+      }
+     },
+     "21e6ae727fcb47a79afba223e8f0fa1c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "2205597ac83a4d0ea9d2524d1ef6e585": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d09f2f1cb5c94ea08f82283ee67746d1",
+       "style": "IPY_MODEL_28500e74ae9d42b4b0b3a8d50b43be56",
+       "value": "Location:(-75.70633642090093,36.09280583966616)"
+      }
+     },
+     "23499d0a3d1b4484a6cba35ea47b22dd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_b4a6d6874ce34e40b720feac68dcdb90",
+       "style": "IPY_MODEL_16cb5cf782b0495aa98514cb48986bb3",
+       "value": "Location:(-75.75098038288328,36.121407404983266)"
+      }
+     },
+     "2456040df2e34673b78473655b317d45": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "24a4f1f11f964c75bae93e0d7733ecf4": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Tiles (C) Esri -- Source: US National Park Service",
+       "max_native_zoom": 18,
+       "max_zoom": 8,
+       "min_native_zoom": 0,
+       "name": "Esri.WorldPhysical",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Physical_Map/MapServer/tile/{z}/{y}/{x}"
+      }
+     },
+     "24e1c752efa245f49659de7fc4fc411a": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map tiles by Stamen Design, CC BY 3.0 -- Map data (C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "max_zoom": 16,
+       "min_native_zoom": 0,
+       "name": "Stamen.Watercolor",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://stamen-tiles-a.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.jpg"
+      }
+     },
+     "2563f1992b574b449d46878a5f2c67fb": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2021</a>",
+       "max_native_zoom": 18,
+       "max_zoom": 15,
+       "min_native_zoom": 0,
+       "name": "Strava.Winter",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://heatmap-external-a.strava.com/tiles/winter/hot/{z}/{x}/{y}.png"
+      }
+     },
+     "2573550879b8416f8e740ba53224095a": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletWMSLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "MRLC",
+       "crs": {
+        "custom": false,
+        "name": "EPSG3857"
+       },
+       "format": "image/png",
+       "layers": "NLCD_2019_Land_Cover_L48",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "NLCD 2019 CONUS Land Cover",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "format",
+        "layers",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "styles",
+        "tile_size",
+        "tms",
+        "transparent",
+        "uppercase"
+       ],
+       "transparent": true,
+       "url": "https://www.mrlc.gov/geoserver/mrlc_display/NLCD_2019_Land_Cover_L48/wms?"
+      }
+     },
+     "25e8743d3e094df2af65c8095c0b2c71": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "267de561b6cc4126ab4f557031e74b64": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "(C) OpenStreetMap contributors, Tiles style by Humanitarian OpenStreetMap Team hosted by OpenStreetMap France",
+       "max_native_zoom": 18,
+       "max_zoom": 19,
+       "min_native_zoom": 0,
+       "name": "OpenStreetMap.HOT",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://a.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png"
+      }
+     },
+     "26f0281152ac4a0b877e781e5cbc8323": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.12371193706116,
+        -75.72297448037082
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_a9b2928b22f34fd59ed8996b7acdfa52",
+       "title": "Location:(-75.72297448037082,36.12371193706116)"
+      }
+     },
+     "28500e74ae9d42b4b0b3a8d50b43be56": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "2854e4d1b50d4c729266cdd7334e1370": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_48e9d2a38fb241509dc0a4c254bee53e",
+       "style": "IPY_MODEL_1c91f90fa21148788f1af90db5462fd2",
+       "value": "Location:(-75.72432853888888,36.126405)"
+      }
+     },
+     "2856a83a9aa94ad4929c2562724f2251": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_c97c86b7270d4645b969025b3e0fcf65",
+       "style": "IPY_MODEL_058ff6d6a2d24672a416565883c19f34",
+       "value": "Location:(-75.74181562010726,36.10678427557642)"
+      }
+     },
+     "288cb5febefb42ee9674ac71ddd42c78": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "28b3dfd39c094edbb96f5b02f722864a": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.10613398011216,
+        -75.74062510133014
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_bcad9afb026b4e3288544c6f223ddb48",
+       "title": "Location:(-75.74062510133014,36.10613398011216)"
+      }
+     },
+     "28e61cd0f1ce429f9f866d3d148ca2e9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_9df19f445fb64ba7a0c487920159b220",
+       "style": "IPY_MODEL_b8cf3ff451f34e13b43e53b05dd79a59",
+       "value": "Location:(-75.71593401543133,36.11043243095848)"
+      }
+     },
+     "2b86f018d89c47f98920431a2c2a0c6c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2bb8b5b4346941419808e1a101cd0ff4": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map data: (C) OpenStreetMap contributors | Map style: (C) OpenFireMap (CC-BY-SA)",
+       "max_native_zoom": 18,
+       "max_zoom": 19,
+       "min_native_zoom": 0,
+       "name": "OpenFireMap",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "http://openfiremap.org/hytiles/{z}/{x}/{y}.png"
+      }
+     },
+     "2bf0830bf900484887137bee92c955b3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "2c018069ee0f453081d896c19637959c": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.12552600106702,
+        -75.72384020614835
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_4a1e8944eef446c2a63b320f64001841",
+       "title": "Location:(-75.72384020614835,36.12552600106702)"
+      }
+     },
+     "2c5d010dfb6a403da1292cbda4e61d26": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.11785652929547,
+        -75.74259628368763
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_140e09f37c2d45ac90220e3331e43805",
+       "title": "Location:(-75.74259628368763,36.11785652929547)"
+      }
+     },
+     "2c7a0f73dd91410ba5f964b8b32975fe": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "2cc4e5ce5ccc465399c2491ecce5f4e6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "2ccb8ab9a42f4150b75505346faca378": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.10896030869337,
+        -75.74708720019528
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_7fe5c0401dcf40b3923244e465a9c423",
+       "title": "Location:(-75.74708720019528,36.10896030869337)"
+      }
+     },
+     "2cdb3d023f06484fb155e25c15642b7c": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletGeoJSONModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "data": {
+        "features": [
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.749844,
+              36.114259
+             ],
+             [
+              -75.749844,
+              36.116259
+             ],
+             [
+              -75.747844,
+              36.116259
+             ],
+             [
+              -75.747844,
+              36.114259
+             ],
+             [
+              -75.749844,
+              36.114259
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 52,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.749595,
+              36.113358
+             ],
+             [
+              -75.749595,
+              36.115358
+             ],
+             [
+              -75.747595,
+              36.115358
+             ],
+             [
+              -75.747595,
+              36.113358
+             ],
+             [
+              -75.749595,
+              36.113358
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 53,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746894,
+              36.115993
+             ],
+             [
+              -75.746894,
+              36.117993
+             ],
+             [
+              -75.744894,
+              36.117993
+             ],
+             [
+              -75.744894,
+              36.115993
+             ],
+             [
+              -75.746894,
+              36.115993
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 89,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746624,
+              36.114914
+             ],
+             [
+              -75.746624,
+              36.116914
+             ],
+             [
+              -75.744624,
+              36.116914
+             ],
+             [
+              -75.744624,
+              36.114914
+             ],
+             [
+              -75.746624,
+              36.114914
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 90,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746354,
+              36.113834
+             ],
+             [
+              -75.746354,
+              36.115834
+             ],
+             [
+              -75.744354,
+              36.115834
+             ],
+             [
+              -75.744354,
+              36.113834
+             ],
+             [
+              -75.746354,
+              36.113834
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 91,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         }
+        ],
+        "type": "FeatureCollection"
+       },
+       "hover_style": {
+        "fillColor": "blue"
+       },
+       "name": "Selected ROIs"
+      }
+     },
+     "2ceda729085e4dcda79aeadf6514c343": {
+      "model_module": "@here/map-widget-for-jupyter",
+      "model_module_version": "^1.1.3",
+      "model_name": "DefaultLayersModel",
+      "state": {
+       "_model_module": "@here/map-widget-for-jupyter",
+       "_model_module_version": "^1.1.3",
+       "_view_count": null,
+       "_view_module": "@here/map-widget-for-jupyter",
+       "_view_module_version": "^1.1.3",
+       "layer_name": "raster.satellite.xbase",
+       "ppi": null
+      }
+     },
+     "2d47e47d2b9c4b14a70c61bc922d218f": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.09194000192228,
+        -75.74262663596114
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_005b2bae1b4d4ec78e9b41815f9b8177",
+       "title": "Location:(-75.74262663596114,36.09194000192228)"
+      }
+     },
+     "2d83e2a8f5954bbf97b0426356258fb5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_9122238ca9ee432bb9ac6651e52e6529",
+       "style": "IPY_MODEL_9079558744314c04be34c55a0835f68d",
+       "value": "Location:(-75.74108066776667,36.10594910246212)"
+      }
+     },
+     "2db08a8f94e04c879693fff2d6deb134": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Justice Map",
+       "max_native_zoom": 18,
+       "max_zoom": 22,
+       "min_native_zoom": 0,
+       "name": "JusticeMap.nonWhite",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://www.justicemap.org/tile/county/nonwhite/{z}/{x}/{y}.png"
+      }
+     },
+     "2dc8fffb1ea34e4e95a27a950ec0ce6c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "2dd3a7734d8b47e4a40faab4d04cc074": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Justice Map",
+       "max_native_zoom": 18,
+       "max_zoom": 22,
+       "min_native_zoom": 0,
+       "name": "JusticeMap.black",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://www.justicemap.org/tile/county/black/{z}/{x}/{y}.png"
+      }
+     },
+     "2f6fc999304240c19bfb4eabb569d9dd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_80b1d9eb9c9541acb364c57599bc6690",
+       "style": "IPY_MODEL_25e8743d3e094df2af65c8095c0b2c71",
+       "value": "Location:(-75.75048862686954,36.12061811060861)"
+      }
+     },
+     "2f7040eab1e74d83bfa1d76cb9419903": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_74cdf6e4508e4ad899e12d0a0ba1c487",
+       "style": "IPY_MODEL_713c5656936c404fa55e72a651c45f54",
+       "value": "Location:(-75.74289278630448,36.09282198135321)"
+      }
+     },
+     "2f858dc8272b414ea5b65033a595cddc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_f817144a827d4b4db4f5932ec80fd79f",
+       "style": "IPY_MODEL_33e229eed5c04df182ff2d1ef5fac822",
+       "value": "Location:(-75.74292345617727,36.11891983886272)"
+      }
+     },
+     "301f0a63c0b04cd48f80712d1617f471": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.09620951899849,
+        -75.70847947825831
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_b87f53c3abba4a4296fae45d5aea1aca",
+       "title": "Location:(-75.70847947825831,36.09620951899849)"
+      }
+     },
+     "3068b017f61249dc841851fe905d1a28": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d53df8ff9536443da0a1042077500e02",
+       "style": "IPY_MODEL_0e3f262c70ca4a8ba450d9c6a80b289a",
+       "value": "Location:(-75.74960191292703,36.117957968781134)"
+      }
+     },
+     "313d8c1b48804032ba2a1ad0fa1c3e47": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "322a05486c524d4ab1fc2d2f46456b3c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "326bbfb15bdc44fb91c74489896923aa": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3291aa221a8145d188f4cfebe25a9c67": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3330495e793a4f6ca7852b10b6c61a79": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Tiles courtesy of the U.S. Geological Survey",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "USGS.USImageryTopo",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryTopo/MapServer/tile/{z}/{y}/{x}"
+      }
+     },
+     "33e229eed5c04df182ff2d1ef5fac822": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "348ac71e68864a9494a5fe886d676080": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.10424937943278,
+        -75.71258652746266
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_477ed57183cb4a40a027fda445d98565",
+       "title": "Location:(-75.71258652746266,36.10424937943278)"
+      }
+     },
+     "34fba5cd5ee849fb94b9dd2c538fce14": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletGeoJSONModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "data": {
+        "features": [
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.72432853888888,
+              36.126405
+             ],
+             [
+              -75.7236345,
+              36.12515573
+             ],
+             [
+              -75.7220345,
+              36.12165573
+             ],
+             [
+              -75.7200345,
+              36.11745573
+             ],
+             [
+              -75.7179345,
+              36.11315573
+             ],
+             [
+              -75.7160345,
+              36.11065573
+             ],
+             [
+              -75.7151345,
+              36.10865573
+             ],
+             [
+              -75.7135345,
+              36.10595573
+             ],
+             [
+              -75.7125345,
+              36.10415573
+             ],
+             [
+              -75.7111345,
+              36.10165573
+             ],
+             [
+              -75.7100345,
+              36.09985573
+             ],
+             [
+              -75.7086345,
+              36.09645573
+             ],
+             [
+              -75.70526489222223,
+              36.091104
+             ]
+            ],
+            [
+             [
+              -75.742208635,
+              36.091104
+             ],
+             [
+              -75.7428345,
+              36.09235573
+             ],
+             [
+              -75.74283483,
+              36.0923584
+             ],
+             [
+              -75.74283517,
+              36.09236108
+             ],
+             [
+              -75.74288853,
+              36.09278793
+             ],
+             [
+              -75.74288899,
+              36.09279165
+             ],
+             [
+              -75.74288946,
+              36.09279537
+             ],
+             [
+              -75.7430345,
+              36.09395573
+             ],
+             [
+              -75.74303498,
+              36.09395672
+             ],
+             [
+              -75.74303545,
+              36.09395771
+             ],
+             [
+              -75.7442345,
+              36.09645573
+             ],
+             [
+              -75.7456345,
+              36.10025573
+             ],
+             [
+              -75.74563467,
+              36.10025761
+             ],
+             [
+              -75.74563484,
+              36.1002595
+             ],
+             [
+              -75.7460345,
+              36.10475573
+             ],
+             [
+              -75.74603518,
+              36.10475797
+             ],
+             [
+              -75.74603586,
+              36.10476022
+             ],
+             [
+              -75.7467345,
+              36.10705573
+             ],
+             [
+              -75.74673496,
+              36.10705821
+             ],
+             [
+              -75.74673542,
+              36.10706069
+             ],
+             [
+              -75.7472345,
+              36.10975573
+             ],
+             [
+              -75.74723485,
+              36.10975687
+             ],
+             [
+              -75.7472352,
+              36.10975802
+             ],
+             [
+              -75.7482345,
+              36.11305573
+             ],
+             [
+              -75.7495345,
+              36.11775573
+             ],
+             [
+              -75.7505345,
+              36.12075573
+             ],
+             [
+              -75.7518345,
+              36.12265573
+             ],
+             [
+              -75.75183439,
+              36.12265801
+             ],
+             [
+              -75.75183428,
+              36.12266029
+             ],
+             [
+              -75.7517345,
+              36.12475573
+             ],
+             [
+              -75.7506153525,
+              36.126405
+             ]
+            ],
+            [
+             [
+              -75.74903784076923,
+              36.126405
+             ],
+             [
+              -75.7480345,
+              36.12495573
+             ],
+             [
+              -75.7474345,
+              36.12315573
+             ],
+             [
+              -75.7462345,
+              36.11835573
+             ],
+             [
+              -75.7451345,
+              36.11395573
+             ],
+             [
+              -75.7439345,
+              36.11105573
+             ],
+             [
+              -75.7429345,
+              36.10805573
+             ],
+             [
+              -75.7407345,
+              36.10555573
+             ],
+             [
+              -75.7400345,
+              36.10925573
+             ],
+             [
+              -75.74003548,
+              36.1092584
+             ],
+             [
+              -75.74003646,
+              36.10926108
+             ],
+             [
+              -75.7411345,
+              36.11225573
+             ],
+             [
+              -75.7422345,
+              36.11465573
+             ],
+             [
+              -75.74223474,
+              36.11465811
+             ],
+             [
+              -75.74223498,
+              36.11466049
+             ],
+             [
+              -75.7425345,
+              36.11765573
+             ],
+             [
+              -75.74253515,
+              36.11765786
+             ],
+             [
+              -75.74253581,
+              36.11765999
+             ],
+             [
+              -75.7433345,
+              36.12025573
+             ],
+             [
+              -75.7443345,
+              36.12335573
+             ],
+             [
+              -75.74433435,
+              36.12335638
+             ],
+             [
+              -75.74433419,
+              36.12335703
+             ],
+             [
+              -75.74361702428095,
+              36.126405
+             ]
+            ]
+           ],
+           "type": "MultiLineString"
+          },
+          "id": "1889",
+          "properties": {
+           "acc": 1,
+           "exs": 44,
+           "f_code": "BA010",
+           "id": "xv279yj9196.1875",
+           "soc": "USA",
+           "style": {
+            "color": "yellow",
+            "dashArray": "5",
+            "fillOpacity": 0.5,
+            "fill_color": "yellow",
+            "opacity": 1,
+            "weight": 4
+           }
+          },
+          "type": "Feature"
+         }
+        ],
+        "type": "FeatureCollection"
+       },
+       "hover_style": {
+        "color": "white",
+        "dashArray": "4",
+        "fillOpacity": 0.7
+       },
+       "style": {
+        "color": "yellow",
+        "dashArray": "5",
+        "fillOpacity": 0.5,
+        "fill_color": "yellow",
+        "opacity": 1,
+        "weight": 4
+       }
+      }
+     },
+     "357ca585d5424e5e8579c9f77ec5e42d": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.098920845461855,
+        -75.74514270043332
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_59bbda71b8fd4656ad3577bee3c2b970",
+       "title": "Location:(-75.74514270043332,36.098920845461855)"
+      }
+     },
+     "35d0e71d153c42ad88da854bb26b6af9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_1578d68f015f4618a35f753559fb7628",
+       "style": "IPY_MODEL_755691222d6c4c0faf24bad3062130a7",
+       "value": "Location:(-75.71865540242354,36.114631863533916)"
+      }
+     },
+     "35dd7cfd75304b749d1588ba6b5c109e": {
+      "model_module": "ipyevents",
+      "model_module_version": "2.0.1",
+      "model_name": "EventModel",
+      "state": {
+       "_supported_key_events": [
+        "keydown",
+        "keyup"
+       ],
+       "_supported_mouse_events": [
+        "click",
+        "auxclick",
+        "dblclick",
+        "mouseenter",
+        "mouseleave",
+        "mousedown",
+        "mouseup",
+        "mousemove",
+        "wheel",
+        "contextmenu",
+        "dragstart",
+        "drag",
+        "dragend",
+        "dragenter",
+        "dragover",
+        "dragleave",
+        "drop"
+       ],
+       "_supported_touch_events": [
+        "touchstart",
+        "touchend",
+        "touchmove",
+        "touchcancel"
+       ],
+       "_view_module": "@jupyter-widgets/controls",
+       "_view_module_version": "1.5.0",
+       "source": "IPY_MODEL_9f28b63a50c647cb8ac9746f1d528b3d",
+       "throttle_or_debounce": "",
+       "watched_events": [
+        "mouseenter",
+        "mouseleave"
+       ],
+       "xy_coordinate_system": ""
+      }
+     },
+     "361be06faf734135a10ab519429ef4a8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "36621d27185349ca9a6fa9efbf7cdf48": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "36d7cf872d5e4c99a39751e65586362c": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.10804125599071,
+        -75.74691700575555
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_afacfa21d7424d8389b572f444c8732d",
+       "title": "Location:(-75.74691700575555,36.10804125599071)"
+      }
+     },
+     "371b9dd1a875428f8875c656d9f28fb6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6d8299f572484ebb805464146f6e3ce9",
+       "style": "IPY_MODEL_496da59e9cce4edb8d19f40e92bf0d00",
+       "value": "Location:(-75.71160422546734,36.10249452547738)"
+      }
+     },
+     "375ae7c236924b5c8840c3a3004a4521": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_779a593b417f40a1870bd1187e81c8a4",
+       "style": "IPY_MODEL_64b43039bfd146318aa1d2c9b00a97cb",
+       "value": "Location:(-75.7446300344755,36.11273660498248)"
+      }
+     },
+     "377a6e7afc4446ba9e34926c74f2c0a0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_3dd74734d6a04c8a83f547bea84adbb0",
+       "style": "IPY_MODEL_e5466133177e4c71ab5cf9eb6c217bc0",
+       "value": "Location:(-75.74754203115378,36.1107705689484)"
+      }
+     },
+     "379f6591c6914606aea126e6e4980cb5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "37f64fe6b5eb4d97b73a00af8dfb4373": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "387dee64bff24971b8b379a8f351408b": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Justice Map",
+       "max_native_zoom": 18,
+       "max_zoom": 22,
+       "min_native_zoom": 0,
+       "name": "JusticeMap.white",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://www.justicemap.org/tile/county/white/{z}/{x}/{y}.png"
+      }
+     },
+     "38a4f236babd4a2bb3f8e8ad48c2b200": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "39e9b7115201492da2facd16cd4d60e4": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "(C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "OpenStreetMap.DE",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://a.tile.openstreetmap.de/tiles/osmde/{z}/{x}/{y}.png"
+      }
+     },
+     "3a019ccf65a14d11a641a838331a5a06": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.11455349190438,
+        -75.74218764087284
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_5731fa19076649f9a92eef3f7fc2db57",
+       "title": "Location:(-75.74218764087284,36.11455349190438)"
+      }
+     },
+     "3a0d2daa27ea467fa451d292b708058d": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map tiles by Stamen Design, CC BY 3.0 -- Map data (C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "Stamen.TerrainBackground",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://stamen-tiles-a.a.ssl.fastly.net/terrain-background/{z}/{x}/{y}.png"
+      }
+     },
+     "3a146af3abb9475294681c683dacc100": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.10855981309512,
+        -75.74310252769837
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_d93dff5f701e41fea21e70ab3edb4ca8",
+       "title": "Location:(-75.74310252769837,36.10855981309512)"
+      }
+     },
+     "3a4c4510750b46d180ed0d8e088b10c4": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.09282198135321,
+        -75.74289278630448
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_2f7040eab1e74d83bfa1d76cb9419903",
+       "title": "Location:(-75.74289278630448,36.09282198135321)"
+      }
+     },
+     "3aac07e83163449f8939c27ab238f6e4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3b4232a8e6b3468cb83b77dfa7f91250": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2021</a>",
+       "max_native_zoom": 18,
+       "max_zoom": 15,
+       "min_native_zoom": 0,
+       "name": "Strava.Water",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://heatmap-external-a.strava.com/tiles/water/blue/{z}/{x}/{y}.png"
+      }
+     },
+     "3c342c46ed314dcfbf2c72fa37a74dc5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3cb9480e6b8b4ca8977b94b6b2014d0c": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletGeoJSONModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "data": {
+        "features": [
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.750342,
+              36.11606
+             ],
+             [
+              -75.750342,
+              36.11806
+             ],
+             [
+              -75.748342,
+              36.11806
+             ],
+             [
+              -75.748342,
+              36.11606
+             ],
+             [
+              -75.750342,
+              36.11606
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 50,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.750093,
+              36.115159
+             ],
+             [
+              -75.750093,
+              36.117159
+             ],
+             [
+              -75.748093,
+              36.117159
+             ],
+             [
+              -75.748093,
+              36.115159
+             ],
+             [
+              -75.750093,
+              36.115159
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 51,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.749844,
+              36.114259
+             ],
+             [
+              -75.749844,
+              36.116259
+             ],
+             [
+              -75.747844,
+              36.116259
+             ],
+             [
+              -75.747844,
+              36.114259
+             ],
+             [
+              -75.749844,
+              36.114259
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 52,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.749595,
+              36.113358
+             ],
+             [
+              -75.749595,
+              36.115358
+             ],
+             [
+              -75.747595,
+              36.115358
+             ],
+             [
+              -75.747595,
+              36.113358
+             ],
+             [
+              -75.749595,
+              36.113358
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 53,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746894,
+              36.115993
+             ],
+             [
+              -75.746894,
+              36.117993
+             ],
+             [
+              -75.744894,
+              36.117993
+             ],
+             [
+              -75.744894,
+              36.115993
+             ],
+             [
+              -75.746894,
+              36.115993
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 89,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746624,
+              36.114914
+             ],
+             [
+              -75.746624,
+              36.116914
+             ],
+             [
+              -75.744624,
+              36.116914
+             ],
+             [
+              -75.744624,
+              36.114914
+             ],
+             [
+              -75.746624,
+              36.114914
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 90,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746354,
+              36.113834
+             ],
+             [
+              -75.746354,
+              36.115834
+             ],
+             [
+              -75.744354,
+              36.115834
+             ],
+             [
+              -75.744354,
+              36.113834
+             ],
+             [
+              -75.746354,
+              36.113834
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 91,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         }
+        ],
+        "type": "FeatureCollection"
+       },
+       "hover_style": {
+        "fillColor": "blue"
+       },
+       "name": "Selected ROIs"
+      }
+     },
+     "3cc3e99436b74083becefb5202561eb9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3cf000e3e98c461c9eaad1888be26702": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.12485815226327,
+        -75.75166499917849
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_4536077997cf466d9958cae2abb327ab",
+       "title": "Location:(-75.75166499917849,36.12485815226327)"
+      }
+     },
+     "3dd74734d6a04c8a83f547bea84adbb0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3e9b20ba36cd4619962230b8012f7e78": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "3ea774e133ee4805a494f21b4e56960e": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletDrawControlModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "circlemarker": {
+        "shapeOptions": {}
+       },
+       "data": [
+        {
+         "geometry": {
+          "coordinates": [
+           [
+            [
+             -75.772945,
+             36.091104
+            ],
+            [
+             -75.772945,
+             36.126405
+            ],
+            [
+             -75.704786,
+             36.126405
+            ],
+            [
+             -75.704786,
+             36.091104
+            ],
+            [
+             -75.772945,
+             36.091104
+            ]
+           ]
+          ],
+          "type": "Polygon"
+         },
+         "properties": {
+          "style": {
+           "Opacity": 0.1,
+           "clickable": true,
+           "color": "green",
+           "fill": true,
+           "fillColor": "green",
+           "fillOpacity": 0.1,
+           "opacity": 0.5,
+           "stroke": true,
+           "weight": 4
+          }
+         },
+         "type": "Feature"
+        }
+       ],
+       "options": [
+        "position"
+       ],
+       "rectangle": {
+        "allowIntersection": false,
+        "drawError": {
+         "color": "#dd253b",
+         "message": "Ops!"
+        },
+        "shapeOptions": {
+         "Opacity": 0.1,
+         "color": "green",
+         "fillColor": "green",
+         "fillOpacity": 0.1
+        },
+        "transform": true
+       }
+      }
+     },
+     "3eb7f0491c1a41faaa7a1550540872a4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "3f1e4ac0b2b54dbb9a7c68fa99b7f40a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ToggleButtonModel",
+      "state": {
+       "icon": "server",
+       "layout": "IPY_MODEL_f3f323eed1fa44c2b4f9f95d57ad5f52",
+       "style": "IPY_MODEL_ce0af72f44dc4d339a9494c1d0b6b53f",
+       "tooltip": "Layers"
+      }
+     },
+     "3fb1b3244b8346e4bde7f19a98084235": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "400561cd04c149de9230504369789a63": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "4037a0c351504613a1baffec2d09825a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "height": "auto",
+       "padding": "0px 0px 0px 4px",
+       "width": "auto"
+      }
+     },
+     "4046e3790c3f411f8161ab42ac1f0138": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Google",
+       "max_native_zoom": 18,
+       "max_zoom": 22,
+       "min_native_zoom": 0,
+       "name": "Google Satellite",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://mt1.google.com/vt/lyrs=s&x={x}&y={y}&z={z}"
+      }
+     },
+     "40b2d8afd7394832a6557995ad9bc9e1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "40e1230ba6a84379ab8b489e50c77d7a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_cb4c0ea516184f98999a2eabeef3d470",
+       "style": "IPY_MODEL_3eb7f0491c1a41faaa7a1550540872a4",
+       "value": "Location:(-75.71209553504248,36.10337186400442)"
+      }
+     },
+     "4101439d4e434559ad7bedec94151e96": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "420f18ac00534791b53e0eb2d9c64888": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Datenquelle: basemap.at",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "BasemapAT.orthofoto",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://maps.wien.gv.at/basemap/bmaporthofoto30cm/normal/google3857/{z}/{y}/{x}.jpeg"
+      }
+     },
+     "4220ea903b6e426899552135d42be328": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_49f2335abdba4294a0957a07c7f16c23",
+       "style": "IPY_MODEL_c601f121e3324187a00d13253e1128a0",
+       "value": "Location:(-75.74172411010603,36.11354215204953)"
+      }
+     },
+     "424cfd5a166348e7a1b9b7ef04a1037e": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
+       "max_native_zoom": 18,
+       "max_zoom": 9,
+       "min_native_zoom": 0,
+       "name": "NASAGIBS.ModisTerraTrueColorCR",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/MODIS_Terra_CorrectedReflectance_TrueColor/default//GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg"
+      }
+     },
+     "426ecbdb84994e74b4fbc2333204edf0": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletDrawControlModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "options": [
+        "position"
+       ],
+       "polygon": {
+        "allowIntersection": false,
+        "drawError": {
+         "color": "#dd253b",
+         "message": "Ops!"
+        },
+        "shapeOptions": {
+         "Opacity": 0.2,
+         "color": "green",
+         "fillColor": "green",
+         "fillOpacity": 0.2
+        },
+        "transform": true
+       },
+       "polyline": {}
+      }
+     },
+     "42a65a5036ce41c4b8bd9a52445a874b": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.11565080735296,
+        -75.74233401041278
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_a19c6c2a01144a1381558e810c537392",
+       "title": "Location:(-75.74233401041278,36.11565080735296)"
+      }
+     },
+     "42c0f81fa0c34f008acaa0339c29a5cc": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.1116650796005,
+        -75.7478130933438
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_16f0c9c3435440e2a5d565a2bdca83a6",
+       "title": "Location:(-75.7478130933438,36.1116650796005)"
+      }
+     },
+     "4302d664c8334817a20a9aaedd3c6735": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.10070073468595,
+        -75.7456740603812
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_91dbeffa8f9b4fceba8e31a20f497427",
+       "title": "Location:(-75.7456740603812,36.10070073468595)"
+      }
+     },
+     "441220cdda2d411186a90bd41d167319": {
+      "model_module": "@here/map-widget-for-jupyter",
+      "model_module_version": "^1.1.3",
+      "model_name": "DefaultLayersModel",
+      "state": {
+       "_model_module": "@here/map-widget-for-jupyter",
+       "_model_module_version": "^1.1.3",
+       "_view_count": null,
+       "_view_module": "@here/map-widget-for-jupyter",
+       "_view_module_version": "^1.1.3",
+       "layer_name": "raster.normal.map",
+       "ppi": null
+      }
+     },
+     "446068f836a547a3b62f01a269c4287c": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.09280583966616,
+        -75.70633642090093
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_2205597ac83a4d0ea9d2524d1ef6e585",
+       "title": "Location:(-75.70633642090093,36.09280583966616)"
+      }
+     },
+     "44785b1f02d443ad9cfc671ca913d85a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_bd3caaa184704bc7961a3c7ec30c204e",
+       "style": "IPY_MODEL_5b7edc33c46d4f6d84e8fe89c0da33b5",
+       "value": "Location:(-75.70740794957962,36.094507679332324)"
+      }
+     },
+     "4536077997cf466d9958cae2abb327ab": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_8cdec17b3a5e47ba93487c700fbc718a",
+       "style": "IPY_MODEL_b85ba37376f640bdba915318700f243c",
+       "value": "Location:(-75.75166499917849,36.12485815226327)"
+      }
+     },
+     "453b6c17241a4e54877532846889dd2d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "45ac1a6ceedb43308bfb055525405775": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Tiles courtesy of OpenStreetMap Sweden -- Map data (C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "Hydda.RoadsAndLabels",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://a.tile.openstreetmap.se/hydda/roads_and_labels/{z}/{x}/{y}.png"
+      }
+     },
+     "4651104c0d9e42ddac9a1b2966d1aee2": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.09804379626511,
+        -75.74481957704504
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_c3052fbc9a824efeb03ba6532589276c",
+       "title": "Location:(-75.74481957704504,36.09804379626511)"
+      }
+     },
+     "46b348d21c7a4c1ebb5b89a90f3f38d4": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.12217880198888,
+        -75.7515081808345
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_19c4eff125564ad8a27d3dd4521ab701",
+       "title": "Location:(-75.7515081808345,36.12217880198888)"
+      }
+     },
+     "4730641e3cdf4901a280d7d079d6ae71": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ToggleButtonModel",
+      "state": {
+       "button_style": "primary",
+       "icon": "adjust",
+       "layout": "IPY_MODEL_c135f5bb89874afe95066053f480318d",
+       "style": "IPY_MODEL_66ff78c2daf24d9b85adcd5643c4c8e7",
+       "tooltip": "Planet imagery"
+      }
+     },
+     "473b8492e9f340ccbbd3c26296901421": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a52fb643557a4adf9bc26133668e69a3",
+       "style": "IPY_MODEL_0c92371398de41f4be1f41bc2862eea9",
+       "value": "Location:(-75.71771163921626,36.11286249212666)"
+      }
+     },
+     "474d256e5f9040a091d320cf62a0fe27": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ToggleButtonModel",
+      "state": {
+       "button_style": "primary",
+       "icon": "camera",
+       "layout": "IPY_MODEL_8e5eb24759764a6d9cba136935e4b9d9",
+       "style": "IPY_MODEL_d5b67a6bbb61415b942a13aad40e107f",
+       "tooltip": "Save map as HTML or image"
+      }
+     },
+     "47563edcf6074a62942146c10fcfd219": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.11372831916115,
+        -75.71821413656707
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_82470d39356b469c9093ebe104207257",
+       "title": "Location:(-75.71821413656707,36.11372831916115)"
+      }
+     },
+     "47655f2eb1f94ef2b67f7ef82b93191a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "477ed57183cb4a40a027fda445d98565": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_e0bc984ba36847e582a35017c8d0e8fc",
+       "style": "IPY_MODEL_08e921f393e94e4fb022596b0129407e",
+       "value": "Location:(-75.71258652746266,36.10424937943278)"
+      }
+     },
+     "48e9d2a38fb241509dc0a4c254bee53e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "49635cf7005941a5a257091e04c343cf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ToggleButtonModel",
+      "state": {
+       "button_style": "primary",
+       "icon": "address-book",
+       "layout": "IPY_MODEL_0e971e22ea98429b8a02c8ec8c8cd379",
+       "style": "IPY_MODEL_bf682e14ae4c4b55a0a88d60982d730b",
+       "tooltip": "Get US Census data"
+      }
+     },
+     "496da59e9cce4edb8d19f40e92bf0d00": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "49d0daeeb21d4d659958d69ba61dbd76": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "49e0d7044adc4d759f646e007aadaa91": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.09716674706836,
+        -75.74449645365677
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_d1af9ed07a234ebdada16cbd1abe1342",
+       "title": "Location:(-75.74449645365677,36.09716674706836)"
+      }
+     },
+     "49f2335abdba4294a0957a07c7f16c23": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4a1e8944eef446c2a63b320f64001841": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_f503d7bf72a742a9bc3d55bf2ec9b294",
+       "style": "IPY_MODEL_2cc4e5ce5ccc465399c2491ecce5f4e6",
+       "value": "Location:(-75.72384020614835,36.12552600106702)"
+      }
+     },
+     "4a2aeaf42761491a95c1e3f2d8bc3719": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "4a30583792d24ff0abe7cf97213555bf": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "(C) OpenStreetMap contributors (C) CARTO",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "CartoDB.Voyager",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://a.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
+      }
+     },
+     "4b01ab00ec334e60aa92dc979fdf7cdf": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d5f2e477b83a4191843bf5d8d915538a",
+       "style": "IPY_MODEL_b1a5888546424bb2899df98ff02d6eda",
+       "value": "Location:(-75.7438061381229,36.110670644368724)"
+      }
+     },
+     "4b256e57558f4b97997a7b49520b26f0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "4b351d9c32f240309f6f09409447a260": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "4b4190c3971b481c93c0eba97745a6ac": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map data: (C) OpenStreetMap contributors | Map style: (C) waymarkedtrails.org (CC-BY-SA)",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "WaymarkedTrails.skating",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://tile.waymarkedtrails.org/skating/{z}/{x}/{y}.png"
+      }
+     },
+     "4bbe30ef6f914b5098059d3643cad23e": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.120230771773876,
+        -75.74670326044347
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_2138764edb134477bd96cee08f35f4e7",
+       "title": "Location:(-75.74670326044347,36.120230771773876)"
+      }
+     },
+     "4be5b3861f314895839a01de4feb3524": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.12188291357662,
+        -75.72213835534932
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_56e9b80d69694f8289a539a4a101e80e",
+       "title": "Location:(-75.72213835534932,36.12188291357662)"
+      }
+     },
+     "4c10963f8b7a4515b2c469ff8d915532": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_c5e90edf7caa4fc58ef91f211a477a16",
+       "style": "IPY_MODEL_a0e7005fdcb6463da78a0c5eee1276ae",
+       "value": "Location:(-75.74412663695226,36.12423913499488)"
+      }
+     },
+     "4c181e26cb404e59a8331cb963d75c4a": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "(C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "max_zoom": 19,
+       "min_native_zoom": 0,
+       "name": "HikeBike.HikeBike",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://tiles.wmflabs.org/hikebike/{z}/{x}/{y}.png"
+      }
+     },
+     "4c21002c5baf4f8a8655ffb82b6bfa44": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "4e25afe8e77a4e3bae577c95f577392e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_684c508e8d2441ea958f53cb5f96de9a",
+       "style": "IPY_MODEL_4b351d9c32f240309f6f09409447a260",
+       "value": "Location:(-75.7450554030486,36.113764579034104)"
+      }
+     },
+     "4e3cd142ab0745c3a1b38a4da76a009b": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
+       "max_native_zoom": 18,
+       "max_zoom": 7,
+       "min_native_zoom": 0,
+       "name": "NASAGIBS.ModisTerraLSTDay",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/MODIS_Terra_Land_Surface_Temp_Day/default//GoogleMapsCompatible_Level7/{z}/{y}/{x}.png"
+      }
+     },
+     "4e7273ff3a9342119f9f30c179375e13": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "4ed6cefa2e6d4586bd5db8ae13a5d013": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Justice Map",
+       "max_native_zoom": 18,
+       "max_zoom": 22,
+       "min_native_zoom": 0,
+       "name": "JusticeMap.income",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://www.justicemap.org/tile/county/income/{z}/{x}/{y}.png"
+      }
+     },
+     "4f020af0c6c04346b73e348fd6f4794e": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "&copy; <a href=\"http://www.gaode.com/\">Gaode.com</a>",
+       "max_native_zoom": 18,
+       "max_zoom": 19,
+       "min_native_zoom": 0,
+       "name": "Gaode.Normal",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "http://webrd01.is.autonavi.com/appmaptile?lang=zh_cn&size=1&scale=1&style=7&x={x}&y={y}&z={z}"
+      }
+     },
+     "4f42466288214b0da8aaa739819c9524": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.098976094110064,
+        -75.7096722969865
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_e051e3f81cd148a8a250b4f96de61c1a",
+       "title": "Location:(-75.7096722969865,36.098976094110064)"
+      }
+     },
+     "4f4509f603d245eea527b5d03f0d02da": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.12061811060861,
+        -75.75048862686954
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_2f6fc999304240c19bfb4eabb569d9dd",
+       "title": "Location:(-75.75048862686954,36.12061811060861)"
+      }
+     },
+     "502621efedee444686795c50bf61dcf7": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
+       "max_native_zoom": 18,
+       "max_zoom": 6,
+       "min_native_zoom": 0,
+       "name": "NASAGIBS.ModisTerraAOD",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/MODIS_Terra_Aerosol/default//GoogleMapsCompatible_Level6/{z}/{y}/{x}.png"
+      }
+     },
+     "506af8f27feb4a228453e88ee3c88406": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5094318cbdb749aeb31dabc0f6e6d365": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "51c9cfbf126d411891a2416f1e837507": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.10940631770024,
+        -75.74008971390425
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_e295c228529a42e287be9f4e2e331e70",
+       "title": "Location:(-75.74008971390425,36.10940631770024)"
+      }
+     },
+     "51fee07610964c9ea860679a761b63ba": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_badc4d8c9f854f0eaf3fc4310aa83724",
+       "style": "IPY_MODEL_8f9fe98f7db9416ab04e501f0a5384aa",
+       "value": "Location:(-75.75019305555537,36.11973139666612)"
+      }
+     },
+     "52157ba80d124d4ebb0ef93c10cb3bab": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.111495327949704,
+        -75.7408556854917
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_e87611b36d814edda5326455f65e8f0d",
+       "title": "Location:(-75.7408556854917,36.111495327949704)"
+      }
+     },
+     "52cd2aac867d4c41a0bfb67cbd913e65": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "52cd5d468d3e48ccb14809911d0dcb83": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "540983ab9090436782300e57a1a3e037": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Justice Map",
+       "max_native_zoom": 18,
+       "max_zoom": 22,
+       "min_native_zoom": 0,
+       "name": "JusticeMap.multi",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://www.justicemap.org/tile/county/multi/{z}/{x}/{y}.png"
+      }
+     },
+     "5436d9411c3444fa821bdc8665ccfce6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ToggleButtonModel",
+      "state": {
+       "button_style": "primary",
+       "icon": "map",
+       "layout": "IPY_MODEL_ad13758cba4e4f898409395aa7299ce6",
+       "style": "IPY_MODEL_f7f272db34974a218507acebbe851c10",
+       "tooltip": "Change basemap"
+      }
+     },
+     "54aaedfa39fc41f78070c4a8b3d18e9c": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "(C) OpenStreetMap contributors & USGS",
+       "max_native_zoom": 18,
+       "max_zoom": 22,
+       "min_native_zoom": 0,
+       "name": "MtbMap",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "http://tile.mtbmap.cz/mtbmap_tiles/{z}/{x}/{y}.png"
+      }
+     },
+     "55367ff771c84f8cb4ee4df417cdcc28": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "55c8b77122db4e639dc98e45d8bc488e": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2021</a>",
+       "max_native_zoom": 18,
+       "max_zoom": 15,
+       "min_native_zoom": 0,
+       "name": "Strava.Ride",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://heatmap-external-a.strava.com/tiles/ride/hot/{z}/{x}/{y}.png"
+      }
+     },
+     "5612b60fc3c04c0ebf0ac826ade9824d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "567ca06b83874297b6cb353a4d2bdd61": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.10832021023489,
+        -75.74021149022583
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_78f85e1df08f4e7eb6f5bbe76261be1b",
+       "title": "Location:(-75.74021149022583,36.10832021023489)"
+      }
+     },
+     "56e9b80d69694f8289a539a4a101e80e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_958a059b3b0644ef9211e83a75941d43",
+       "style": "IPY_MODEL_5eb3f7f78b9a490aab49ae8ca8822c77",
+       "value": "Location:(-75.72213835534932,36.12188291357662)"
+      }
+     },
+     "56eaa4007081411da57985997a40a381": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.12346171770498,
+        -75.74753649590166
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_5eab31fe82ef4481a47e21433733270a",
+       "title": "Location:(-75.74753649590166,36.12346171770498)"
+      }
+     },
+     "570d978d891d4467adef2280b0e2246a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5731fa19076649f9a92eef3f7fc2db57": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_82462577d008409398558507b31ca869",
+       "style": "IPY_MODEL_40b2d8afd7394832a6557995ad9bc9e1",
+       "value": "Location:(-75.74218764087284,36.11455349190438)"
+      }
+     },
+     "5876ab0ae5344c659b1cf0e0e6904e7a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "58e2ec4577be4157af87615e0d4512f3": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "&copy; <a href=\"http://www.gaode.com/\">Gaode.com</a>",
+       "max_native_zoom": 18,
+       "max_zoom": 19,
+       "min_native_zoom": 0,
+       "name": "Gaode.Satellite",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "http://webst01.is.autonavi.com/appmaptile?style=6&x={x}&y={y}&z={z}"
+      }
+     },
+     "58f8d568a989487ab772cc237f0cfc59": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_361be06faf734135a10ab519429ef4a8",
+       "style": "IPY_MODEL_eb776508f6e54cad8d4c6470f3031f87",
+       "value": "Location:(-75.72127726625094,36.12006553912696)"
+      }
+     },
+     "59bbda71b8fd4656ad3577bee3c2b970": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_eceabdbe0e6f49cc956ec5e47aa8c4a3",
+       "style": "IPY_MODEL_400561cd04c149de9230504369789a63",
+       "value": "Location:(-75.74514270043332,36.098920845461855)"
+      }
+     },
+     "59daa2eda0014b60b855e5dbdc438c0b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ToggleButtonModel",
+      "state": {
+       "button_style": "primary",
+       "icon": "question",
+       "layout": "IPY_MODEL_de1b1e47e5eb42f18fcfeba68e246986",
+       "style": "IPY_MODEL_96188ff47c1f443b87d1c4c5348845a2",
+       "tooltip": "Get help"
+      }
+     },
+     "59dcebe27ec2483ea7e296803cff2cc0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ToggleButtonModel",
+      "state": {
+       "button_style": "primary",
+       "icon": "fast-forward",
+       "layout": "IPY_MODEL_80fb4b4f73974397bbf3cf885bb39044",
+       "style": "IPY_MODEL_21e6ae727fcb47a79afba223e8f0fa1c",
+       "tooltip": "Activate the time slider"
+      }
+     },
+     "5a0acd588e5646c2bace1b24ace1ed7c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "5aad325ffcc646c4a3dcdcd7a79d0c4b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ToggleButtonModel",
+      "state": {
+       "button_style": "primary",
+       "icon": "search",
+       "layout": "IPY_MODEL_a06a89d6d18d4db7bee05f908153984d",
+       "style": "IPY_MODEL_da5626455eef43f4bc011eb0a9e4892d",
+       "tooltip": "Search XYZ tile services"
+      }
+     },
+     "5abb8e79df824849bb50fdac84ee2825": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_68d4a645e1df43a0bdb25554a7268247",
+       "style": "IPY_MODEL_edcadeebab034e36a1d117a6d762d419",
+       "value": "Location:(-75.74840459138716,36.12549030644811)"
+      }
+     },
+     "5acd693af1704d8ead28c4e83fffa86e": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.105128378365755,
+        -75.71307486020319
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_ce3ee280e8eb4c579ab573f90cc78b3e",
+       "title": "Location:(-75.71307486020319,36.105128378365755)"
+      }
+     },
+     "5b00fff6160a496f97f91a90c23aeff1": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletScaleControlModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "imperial": true,
+       "max_width": 100,
+       "metric": true,
+       "options": [
+        "imperial",
+        "max_width",
+        "metric",
+        "position",
+        "update_when_idle"
+       ],
+       "position": "bottomleft",
+       "update_when_idle": false
+      }
+     },
+     "5b4240a5c1a2499cb98bf626d164b3bf": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.12563157613164,
+        -75.75114017583925
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_e292c64df2cb48589b52b5bfde80976b",
+       "title": "Location:(-75.75114017583925,36.12563157613164)"
+      }
+     },
+     "5b7edc33c46d4f6d84e8fe89c0da33b5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "5bffc17bb47343b7b220bfc5ac50c049": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Tiles (C) Esri -- National Geographic, Esri, DeLorme, NAVTEQ, UNEP-WCMC, USGS, NASA, ESA, METI, NRCAN, GEBCO, NOAA, iPC",
+       "max_native_zoom": 18,
+       "max_zoom": 16,
+       "min_native_zoom": 0,
+       "name": "Esri.NatGeoWorldMap",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://server.arcgisonline.com/ArcGIS/rest/services/NatGeo_World_Map/MapServer/tile/{z}/{y}/{x}"
+      }
+     },
+     "5c3531fd074c491cb9a957aeb4f53824": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5c58690147954620994ea4ee47f7ce10": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map tiles by Stamen Design, CC BY 3.0 -- Map data (C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "Stamen.TonerBackground",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://stamen-tiles-a.a.ssl.fastly.net/toner-background/{z}/{x}/{y}.png"
+      }
+     },
+     "5c99b50058db40a7a12fa17cac0e4790": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "5cf58787641f4098b683763d3b44fcb8": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map memomaps.de CC-BY-SA, map data (C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "OPNVKarte",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://tileserver.memomaps.de/tilegen/{z}/{x}/{y}.png"
+      }
+     },
+     "5d70d81bbbee428d97de6ff5f11a0146": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "5d71560731c9400490e62db164aab28c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_da0baa34ca80408e80397f3111bc6fd5",
+       "style": "IPY_MODEL_dfdc3ffba8bb4097b96a1bb7aa6592e4",
+       "value": "Location:(-75.74300871497711,36.093749442705736)"
+      }
+     },
+     "5d8d0c8edf2d4d59924dd723ada42fdc": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5dc6389e99794378aa6bfc4298f6e283": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "(C) Stadia Maps, (C) OpenMapTiles (C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "Stadia.AlidadeSmooth",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://tiles.stadiamaps.com/tiles/alidade_smooth/{z}/{x}/{y}.png"
+      }
+     },
+     "5e37a4c1fbb74d65bcc76f358b675264": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_744066d434fe4adf802701877914a93c",
+       "style": "IPY_MODEL_03909292690d495696f0596bfb5fac70",
+       "value": "Location:(-75.7438718306166,36.12532206749744)"
+      }
+     },
+     "5e3918f7fcb54a2899543555daf89296": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5eab31fe82ef4481a47e21433733270a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6fc2edcdcad34b84a7cd0fdff0816be3",
+       "style": "IPY_MODEL_dcaf1b1f150e4c96ae8aa04151ef5aa9",
+       "value": "Location:(-75.74753649590166,36.12346171770498)"
+      }
+     },
+     "5eb3f7f78b9a490aab49ae8ca8822c77": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "5f2c155c083c4ba4a852b80a84381f13": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5f4489fa22b447cd86bd6d8f7393e285": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5f867533aac64680af1fcc72f07538b7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5f9f12e334df4ae293ad762b81c9af3a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ToggleButtonModel",
+      "state": {
+       "button_style": "primary",
+       "icon": "info",
+       "layout": "IPY_MODEL_4037a0c351504613a1baffec2d09825a",
+       "style": "IPY_MODEL_adc7eec9d97e4cf194a4b68827464fae",
+       "tooltip": "Get COG/STAC pixel value"
+      }
+     },
+     "5fde9a4ad09c44199b7408953cfc03b4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "5ff70459c2484d2ab468965c40c48b93": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "60e32f5454b24468892885dfaef6c1d8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "61226151acce49d5b0a12d3b96d2f33f": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Justice Map",
+       "max_native_zoom": 18,
+       "max_zoom": 22,
+       "min_native_zoom": 0,
+       "name": "JusticeMap.plurality",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://www.justicemap.org/tile/county/plural/{z}/{x}/{y}.png"
+      }
+     },
+     "61584a3952f945ea8fb861fbacfb321f": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletZoomControlModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "options": [
+        "position",
+        "zoom_in_text",
+        "zoom_in_title",
+        "zoom_out_text",
+        "zoom_out_title"
+       ]
+      }
+     },
+     "617cd9de2c754d5fa7530fa82b449608": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.104424766023904,
+        -75.74600508133976
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_966fc50e63e248c8be36ad63951326a8",
+       "title": "Location:(-75.74600508133976,36.104424766023904)"
+      }
+     },
+     "61967e8e28df4de7be19142485604fc9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a435d6196b474560915bf7baf62972e8",
+       "style": "IPY_MODEL_7c477d68e7544d81a6888e0f73ef4e54",
+       "value": "Location:(-75.74041829577799,36.10722709517353)"
+      }
+     },
+     "6204d0fee64a4d7daca73259363fcd23": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map data: (C) OpenStreetMap contributors | Map style: (C) waymarkedtrails.org (CC-BY-SA)",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "WaymarkedTrails.cycling",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://tile.waymarkedtrails.org/cycling/{z}/{x}/{y}.png"
+      }
+     },
+     "6285fcd658ed4245b7757154fcb99393": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "(C) OpenStreetMap France | (C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "OpenStreetMap.France",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://a.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png"
+      }
+     },
+     "634fe2f4fbf84c68be1f1bc7a4e24ccc": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "63a1100c8fa9451b94490e95c93fb878": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "(C) OpenStreetMap contributors (C) CARTO",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "CartoDB.VoyagerNoLabels",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://a.basemaps.cartocdn.com/rastertiles/voyager_nolabels/{z}/{x}/{y}.png"
+      }
+     },
+     "63b7428d2e72472ca6270afbb5180d7c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "6436314975ab4584913b5b31f35ad54d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "64b43039bfd146318aa1d2c9b00a97cb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "656aef883ce941cf967abc513c740479": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "65c1836119c3462695f1ccb092eabed8": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletGeoJSONModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "data": {
+        "features": [
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.749844,
+              36.114259
+             ],
+             [
+              -75.749844,
+              36.116259
+             ],
+             [
+              -75.747844,
+              36.116259
+             ],
+             [
+              -75.747844,
+              36.114259
+             ],
+             [
+              -75.749844,
+              36.114259
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 52,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.749595,
+              36.113358
+             ],
+             [
+              -75.749595,
+              36.115358
+             ],
+             [
+              -75.747595,
+              36.115358
+             ],
+             [
+              -75.747595,
+              36.113358
+             ],
+             [
+              -75.749595,
+              36.113358
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 53,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746894,
+              36.115993
+             ],
+             [
+              -75.746894,
+              36.117993
+             ],
+             [
+              -75.744894,
+              36.117993
+             ],
+             [
+              -75.744894,
+              36.115993
+             ],
+             [
+              -75.746894,
+              36.115993
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 89,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746624,
+              36.114914
+             ],
+             [
+              -75.746624,
+              36.116914
+             ],
+             [
+              -75.744624,
+              36.116914
+             ],
+             [
+              -75.744624,
+              36.114914
+             ],
+             [
+              -75.746624,
+              36.114914
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 90,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746354,
+              36.113834
+             ],
+             [
+              -75.746354,
+              36.115834
+             ],
+             [
+              -75.744354,
+              36.115834
+             ],
+             [
+              -75.744354,
+              36.113834
+             ],
+             [
+              -75.746354,
+              36.113834
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 91,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         }
+        ],
+        "type": "FeatureCollection"
+       },
+       "hover_style": {
+        "fillColor": "blue"
+       },
+       "name": "Selected ROIs"
+      }
+     },
+     "65e85e9fd94f455caf484f92669ef0f5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d3ea752dd872410aa0b8bd557ae11112",
+       "style": "IPY_MODEL_326bbfb15bdc44fb91c74489896923aa",
+       "value": "Location:(-75.7442715720071,36.123160653222)"
+      }
+     },
+     "663f43d2ba93488db7f4c99f8b768c1d": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.11045082282497,
+        -75.74047269969797
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_6e1eec2e1942475e970076a61605f002",
+       "title": "Location:(-75.74047269969797,36.11045082282497)"
+      }
+     },
+     "666967d882204115aec2be88986d439c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_7d4a4574a1454e25b99ef8dd4a91bac4",
+       "style": "IPY_MODEL_183a2a47e1e1462989d15c8913199aa7",
+       "value": "Location:(-75.742208635,36.091104)"
+      }
+     },
+     "66d891bfc24844c386cddcdd246a88cb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "66ff78c2daf24d9b85adcd5643c4c8e7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "670e1b367cef4e69905f1f89dfb08261": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.1107705689484,
+        -75.74754203115378
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_377a6e7afc4446ba9e34926c74f2c0a0",
+       "title": "Location:(-75.74754203115378,36.1107705689484)"
+      }
+     },
+     "684c508e8d2441ea958f53cb5f96de9a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "68c4d2ef1fcb4b47b010e893736adf42": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "68d4a645e1df43a0bdb25554a7268247": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "696e2fa7c39440e292fb7bd93beb518a": {
+      "model_module": "@here/map-widget-for-jupyter",
+      "model_module_version": "^1.1.3",
+      "model_name": "DefaultLayersModel",
+      "state": {
+       "_model_module": "@here/map-widget-for-jupyter",
+       "_model_module_version": "^1.1.3",
+       "_view_count": null,
+       "_view_module": "@here/map-widget-for-jupyter",
+       "_view_module_version": "^1.1.3",
+       "layer_name": "raster.terrain.map",
+       "ppi": null
+      }
+     },
+     "699ab69fb4ff4afcb5172e754e81ccf8": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.10594910246212,
+        -75.74108066776667
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_2d83e2a8f5954bbf97b0426356258fb5",
+       "title": "Location:(-75.74108066776667,36.10594910246212)"
+      }
+     },
+     "69ba212b3a184ed69e592826e379c566": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d23d2d5fa81b4e25a39b68d1c35fa0a9",
+       "style": "IPY_MODEL_0ce7e102fee44270a6ff7b75dc2ba237",
+       "value": "Location:(-75.74697308272417,36.12131006089669)"
+      }
+     },
+     "6a2bedf0367949489265263c7778ab0a": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.12423913499488,
+        -75.74412663695226
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_4c10963f8b7a4515b2c469ff8d915532",
+       "title": "Location:(-75.74412663695226,36.12423913499488)"
+      }
+     },
+     "6b5b57db251247f98fee9a8943ee4d36": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "GridBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_5436d9411c3444fa821bdc8665ccfce6",
+        "IPY_MODEL_bbb67225841d46d4b36eca9e9656b1ec",
+        "IPY_MODEL_4730641e3cdf4901a280d7d079d6ae71",
+        "IPY_MODEL_a5351931dad84154b2811a62cf1c3c0b",
+        "IPY_MODEL_c72dc77297a54d8ca6134e34ba4db112",
+        "IPY_MODEL_59dcebe27ec2483ea7e296803cff2cc0",
+        "IPY_MODEL_13fc414c5605426dadcac69862bee518",
+        "IPY_MODEL_474d256e5f9040a091d320cf62a0fe27",
+        "IPY_MODEL_49635cf7005941a5a257091e04c343cf",
+        "IPY_MODEL_5f9f12e334df4ae293ad762b81c9af3a",
+        "IPY_MODEL_5aad325ffcc646c4a3dcdcd7a79d0c4b",
+        "IPY_MODEL_dcf57f7a135745279586a1fb16185143",
+        "IPY_MODEL_6c8f34b24e46456db24ad5a4a04c585a",
+        "IPY_MODEL_03842fcea5c4401b97c150e9a36a1885",
+        "IPY_MODEL_59daa2eda0014b60b855e5dbdc438c0b"
+       ],
+       "layout": "IPY_MODEL_8f4a3e6fc9bc42ee806660dd1a5726bc"
+      }
+     },
+     "6b97d67d8f164e9693e0f74b77da153a": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Datenquelle: basemap.at",
+       "max_native_zoom": 18,
+       "max_zoom": 19,
+       "min_native_zoom": 0,
+       "name": "BasemapAT.surface",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://maps.wien.gv.at/basemap/bmapoberflaeche/grau/google3857/{z}/{y}/{x}.jpeg"
+      }
+     },
+     "6c3b613d350f4cdb8a1bc66ac9d94a57": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.110670644368724,
+        -75.7438061381229
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_4b01ab00ec334e60aa92dc979fdf7cdf",
+       "title": "Location:(-75.7438061381229,36.110670644368724)"
+      }
+     },
+     "6c49db5c1e12413bbcda5cdd6c25c31f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_896721fc5d0b475d9a4104e5cca45e23",
+       "style": "IPY_MODEL_b452b81bd4ae49a2adfa7f061b312b17",
+       "value": "Location:(-75.71111146488822,36.101618036180724)"
+      }
+     },
+     "6c8f34b24e46456db24ad5a4a04c585a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ToggleButtonModel",
+      "state": {
+       "button_style": "primary",
+       "icon": "smile-o",
+       "layout": "IPY_MODEL_1bad01dcf92246318d0df71d33d0c4ac",
+       "style": "IPY_MODEL_e0a353cd33a34f7f8368f6cdd49720b8",
+       "tooltip": "This is a placeholder"
+      }
+     },
+     "6c91489331784ed5b4fad1940acfd4fb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6d4a25b5d3e64f36857071d49d83213c": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Kaartgegevens (C) Kadaster",
+       "max_native_zoom": 18,
+       "max_zoom": 19,
+       "min_native_zoom": 0,
+       "name": "nlmaps.luchtfoto",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://service.pdok.nl/hwh/luchtfotorgb/wmts/v1_0/Actueel_ortho25/EPSG:3857/{z}/{x}/{y}.jpeg"
+      }
+     },
+     "6d74f8f207a945838c712059d6eaaba2": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.09990202044353,
+        -75.71006278860439
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_ea0c505d52924bde9ed263611dcf0094",
+       "title": "Location:(-75.71006278860439,36.09990202044353)"
+      }
+     },
+     "6d8299f572484ebb805464146f6e3ce9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "6dd096bf110d495da82449a1992a6307": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Kaartgegevens (C) Kadaster",
+       "max_native_zoom": 18,
+       "max_zoom": 19,
+       "min_native_zoom": 0,
+       "name": "nlmaps.grijs",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/grijs/EPSG:3857/{z}/{x}/{y}.png"
+      }
+     },
+     "6ddf82c59c6f40c1be72ec9efc0bf911": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletWidgetControlModel",
+      "state": {
+       "_model_module": "jupyter-leaflet",
+       "_model_module_version": "^0.15.0",
+       "_view_count": null,
+       "_view_module": "jupyter-leaflet",
+       "_view_module_version": "^0.15.0",
+       "options": [
+        "position",
+        "transparent_bg"
+       ],
+       "position": "topright",
+       "widget": "IPY_MODEL_9f28b63a50c647cb8ac9746f1d528b3d"
+      }
+     },
+     "6e0aea67add34c2bbe606ceae0c1f704": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_506af8f27feb4a228453e88ee3c88406",
+       "style": "IPY_MODEL_1d33c113c74544618eec5865f81edda7",
+       "value": "Location:(-75.74674681131582,36.107122203288064)"
+      }
+     },
+     "6e1eec2e1942475e970076a61605f002": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_02d4bbc8642749a69b1b46de221069a5",
+       "style": "IPY_MODEL_5094318cbdb749aeb31dabc0f6e6d365",
+       "value": "Location:(-75.74047269969797,36.11045082282497)"
+      }
+     },
+     "6e36cf6ae2974ca2a8db27e1cb111e3e": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMapModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "bottom": 13163306,
+       "center": [
+        36.115707514770676,
+        -75.74644625186922
+       ],
+       "controls": [
+        "IPY_MODEL_61584a3952f945ea8fb861fbacfb321f",
+        "IPY_MODEL_cd3db9533f2d42c684cee3ac9c116a66",
+        "IPY_MODEL_5b00fff6160a496f97f91a90c23aeff1",
+        "IPY_MODEL_6ddf82c59c6f40c1be72ec9efc0bf911",
+        "IPY_MODEL_3ea774e133ee4805a494f21b4e56960e"
+       ],
+       "default_style": "IPY_MODEL_b87a1715fddc4be191d661e705189645",
+       "dragging_style": "IPY_MODEL_076be8162c6c42d48191ee18fd7d6b80",
+       "east": -75.74072241783144,
+       "fullscreen": false,
+       "interpolation": "bilinear",
+       "layers": [
+        "IPY_MODEL_a687033714ad4dea941b6944be940912",
+        "IPY_MODEL_34fba5cd5ee849fb94b9dd2c538fce14",
+        "IPY_MODEL_eb7bd4e637ae403eaa67f99af3ad6dbc",
+        "IPY_MODEL_ce506d02f07d49238a6a720a4161291c",
+        "IPY_MODEL_85aa11b5927d40208f7be8cf79395449"
+       ],
+       "layout": "IPY_MODEL_fa95ab5137ac48feaa46828eaecdda29",
+       "left": 9716601.517317794,
+       "max_zoom": 24,
+       "modisdate": "2022-01-24",
+       "north": 36.11830837694028,
+       "options": [
+        "bounce_at_zoom_limits",
+        "box_zoom",
+        "center",
+        "close_popup_on_click",
+        "double_click_zoom",
+        "dragging",
+        "fullscreen",
+        "inertia",
+        "inertia_deceleration",
+        "inertia_max_speed",
+        "interpolation",
+        "keyboard",
+        "keyboard_pan_offset",
+        "keyboard_zoom_offset",
+        "max_zoom",
+        "min_zoom",
+        "prefer_canvas",
+        "scroll_wheel_zoom",
+        "tap",
+        "tap_tolerance",
+        "touch_zoom",
+        "world_copy_jump",
+        "zoom",
+        "zoom_animation_threshold",
+        "zoom_delta",
+        "zoom_snap",
+        "zoom_start"
+       ],
+       "prefer_canvas": false,
+       "right": 9717669,
+       "scroll_wheel_zoom": true,
+       "south": 36.11310735442044,
+       "style": "IPY_MODEL_b87a1715fddc4be191d661e705189645",
+       "top": 13162705.909088135,
+       "west": -75.75217526452525,
+       "window_url": "http://localhost:8888/lab/tree/Prototype%206_CoastSat_download_ROIs.ipynb",
+       "zoom": 17
+      }
+     },
+     "6e657a8f395a43328a2d27de28d17a65": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "height": "28px",
+       "padding": "0px 0px 0px 4px",
+       "width": "28px"
+      }
+     },
+     "6f5a876ba9d7466e99836fb32fb30069": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Kaartgegevens (C) Kadaster",
+       "max_native_zoom": 18,
+       "max_zoom": 19,
+       "min_native_zoom": 0,
+       "name": "nlmaps.pastel",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/pastel/EPSG:3857/{z}/{x}/{y}.png"
+      }
+     },
+     "6fc2edcdcad34b84a7cd0fdff0816be3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7023d1ae47f64c0d8677c1aa6d481e76": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "709261649d65493fba868798e3aa598a": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Geoportail France",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "GeoportailFrance.plan",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://wxs.ign.fr/choisirgeoportail/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE=normal&TILEMATRIXSET=PM&FORMAT=image/png&LAYER=GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}"
+      }
+     },
+     "70d64ac21ccc4758bbdc405f06ba40cc": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.116992904405436,
+        -75.74589379360137
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_e38409848e7a45aa8d71c58f9e0287f8",
+       "title": "Location:(-75.74589379360137,36.116992904405436)"
+      }
+     },
+     "713c5656936c404fa55e72a651c45f54": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "71d9f934b30940d0b8d14e34ef4af00c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "72fe1c8486084cb89eb53ddec1734018": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map data: (C) OpenSeaMap contributors",
+       "max_native_zoom": 18,
+       "max_zoom": 22,
+       "min_native_zoom": 0,
+       "name": "OpenSeaMap",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://tiles.openseamap.org/seamark/{z}/{x}/{y}.png"
+      }
+     },
+     "736e67af1f6a48faabf5898d0abb5bed": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.11615948651872,
+        -75.74909298584559
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_85ece48972bc4ddcb547615a994a08ad",
+       "title": "Location:(-75.74909298584559,36.11615948651872)"
+      }
+     },
+     "73cd27c0138b4479a0542cba7dd346d6": {
+      "model_module": "@here/map-widget-for-jupyter",
+      "model_module_version": "^1.1.3",
+      "model_name": "DefaultLayersModel",
+      "state": {
+       "_model_module": "@here/map-widget-for-jupyter",
+       "_model_module_version": "^1.1.3",
+       "_view_count": null,
+       "_view_module": "@here/map-widget-for-jupyter",
+       "_view_module_version": "^1.1.3",
+       "ppi": null
+      }
+     },
+     "744066d434fe4adf802701877914a93c": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "745f240b66f04b56837e6c083d8ac01f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_b9d9ed6e55874155985aedfc47402b9d",
+       "style": "IPY_MODEL_5a0acd588e5646c2bace1b24ace1ed7c",
+       "value": "Location:(-75.74126057933923,36.11253081219468)"
+      }
+     },
+     "7463293d719a4403a9395cb2bd1b7502": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.10722709517353,
+        -75.74041829577799
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_61967e8e28df4de7be19142485604fc9",
+       "title": "Location:(-75.74041829577799,36.10722709517353)"
+      }
+     },
+     "74cdf6e4508e4ad899e12d0a0ba1c487": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "75175ebcd7cb49aa9dbf364bd6972a0d": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
+       "max_native_zoom": 18,
+       "max_zoom": 7,
+       "min_native_zoom": 0,
+       "name": "NASAGIBS.ModisTerraChlorophyll",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/MODIS_Terra_Chlorophyll_A/default//GoogleMapsCompatible_Level7/{z}/{y}/{x}.png"
+      }
+     },
+     "75291dd6a3324d1b972d94df5b80be84": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Tiles (C) Esri -- Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community",
+       "max_native_zoom": 18,
+       "max_zoom": 22,
+       "min_native_zoom": 0,
+       "name": "Esri.WorldImagery",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
+      }
+     },
+     "755691222d6c4c0faf24bad3062130a7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "76bdcb7c39414b6e86e0912ab02a0a38": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.10163174252044,
+        -75.74575681562084
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_89254a7fba6040d2aa1a6cddb61fec6a",
+       "title": "Location:(-75.74575681562084,36.10163174252044)"
+      }
+     },
+     "76efc10440bf494383b62d62fecf3bb8": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.09545357866556,
+        -75.743753467199
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_a03aba49b7814edb9d4f991a3bcbaa1b",
+       "title": "Location:(-75.743753467199,36.09545357866556)"
+      }
+     },
+     "771dd91628b04d84a39d7fef0c0935cd": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map tiles by Stamen Design, CC BY 3.0 -- Map data (C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "Stamen.TonerLines",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://stamen-tiles-a.a.ssl.fastly.net/toner-lines/{z}/{x}/{y}.png"
+      }
+     },
+     "779a593b417f40a1870bd1187e81c8a4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "77bbcc92290c48cda0ac012e8da26fd7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "78799647211440a79ec3b241be5cbe63": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_3e9b20ba36cd4619962230b8012f7e78",
+       "style": "IPY_MODEL_94556bd91ecd46df9c2450b8bed6d1c6",
+       "value": "Location:(-75.72170958108573,36.120973400280036)"
+      }
+     },
+     "78f85e1df08f4e7eb6f5bbe76261be1b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a8e1a3b99bc0439eb05b678d2b129cd5",
+       "style": "IPY_MODEL_98afa40622884cafa1786a3dfb938775",
+       "value": "Location:(-75.74021149022583,36.10832021023489)"
+      }
+     },
+     "78fe4b788a2f4c3ca220a1a7364b363b": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map data: (C) OpenStreetMap contributors, SRTM | Map style: (C) OpenTopoMap (CC-BY-SA)",
+       "max_native_zoom": 18,
+       "max_zoom": 17,
+       "min_native_zoom": 0,
+       "name": "OpenTopoMap",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://a.tile.opentopomap.org/{z}/{x}/{y}.png"
+      }
+     },
+     "798acf5f0ef0404a85d1bdbefa9094ec": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "79b0a9ed1c4748c8806178fb13f6dfc8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7a814d0c3ed54f7d84c4e5a21bb60476": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.123160653222,
+        -75.7442715720071
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_65e85e9fd94f455caf484f92669ef0f5",
+       "title": "Location:(-75.7442715720071,36.123160653222)"
+      }
+     },
+     "7abf6dced78f4f79acaeaa5e6a92e74b": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Tiles (C) Esri -- Esri, DeLorme, NAVTEQ",
+       "max_native_zoom": 18,
+       "max_zoom": 16,
+       "min_native_zoom": 0,
+       "name": "Esri.WorldGrayCanvas",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}"
+      }
+     },
+     "7bd1bed1e5af40c3bc0556dc61cc9eb8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7c129cc8eaa84a42a7eebf528cfa6248": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7c477d68e7544d81a6888e0f73ef4e54": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7c944b5948254660866866441903ef7c": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.11734249665222,
+        -75.71997919999295
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_cc40b5f17dea499c880bdef27ef2a2a3",
+       "title": "Location:(-75.71997919999295,36.11734249665222)"
+      }
+     },
+     "7cb1a486441647f39ea646c570a2d244": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map data: (C) OpenStreetMap contributors | Map style: (C) waymarkedtrails.org (CC-BY-SA)",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "WaymarkedTrails.slopes",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://tile.waymarkedtrails.org/slopes/{z}/{x}/{y}.png"
+      }
+     },
+     "7cf14672f3404aefab86b71fcfaa19e9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7d0a1e9b8e48492c87696e0f13ad4fa8": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletGeoJSONModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "data": {
+        "features": [
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746894,
+              36.115993
+             ],
+             [
+              -75.746894,
+              36.117993
+             ],
+             [
+              -75.744894,
+              36.117993
+             ],
+             [
+              -75.744894,
+              36.115993
+             ],
+             [
+              -75.746894,
+              36.115993
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 89,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746624,
+              36.114914
+             ],
+             [
+              -75.746624,
+              36.116914
+             ],
+             [
+              -75.744624,
+              36.116914
+             ],
+             [
+              -75.744624,
+              36.114914
+             ],
+             [
+              -75.746624,
+              36.114914
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 90,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         }
+        ],
+        "type": "FeatureCollection"
+       },
+       "hover_style": {
+        "fillColor": "blue"
+       },
+       "name": "Selected ROIs"
+      }
+     },
+     "7d4a4574a1454e25b99ef8dd4a91bac4": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7d9a972ce0fa473c834833c5e6371c2f": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.114631863533916,
+        -75.71865540242354
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_35d0e71d153c42ad88da854bb26b6af9",
+       "title": "Location:(-75.71865540242354,36.114631863533916)"
+      }
+     },
+     "7d9d55ef368844569d77e33f22f22dde": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Datenquelle: basemap.at",
+       "max_native_zoom": 18,
+       "max_zoom": 19,
+       "min_native_zoom": 0,
+       "name": "BasemapAT.highdpi",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://maps.wien.gv.at/basemap/bmaphidpi/normal/google3857/{z}/{y}/{x}.jpeg"
+      }
+     },
+     "7dd53463a34d4332a6328246c594c803": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_4b256e57558f4b97997a7b49520b26f0",
+       "style": "IPY_MODEL_cf0447a6308b4abba5a0c9344365bb21",
+       "value": "Location:(-75.74244470740999,36.11675779210832)"
+      }
+     },
+     "7e74797415454d629f97eb2e6107e89d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7eee3efc599d4a5d853794b5e129dfc2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "7f1944dd040a458fb50c6ed10d1647f5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "7fd0224ef17c4eb78cc94eff8fdd408d": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map data: (C) OpenStreetMap contributors & ODbL, (C) www.opensnowmap.org CC-BY-SA",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "OpenSnowMap.pistes",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://tiles.opensnowmap.org/pistes/{z}/{x}/{y}.png"
+      }
+     },
+     "7fe5c0401dcf40b3923244e465a9c423": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_b8ab558997d4407cab4f49c89f7b34a9",
+       "style": "IPY_MODEL_4101439d4e434559ad7bedec94151e96",
+       "value": "Location:(-75.74708720019528,36.10896030869337)"
+      }
+     },
+     "804aa881054d41bdae858da8fd67601e": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletGeoJSONModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "data": {
+        "features": [
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.750093,
+              36.115159
+             ],
+             [
+              -75.750093,
+              36.117159
+             ],
+             [
+              -75.748093,
+              36.117159
+             ],
+             [
+              -75.748093,
+              36.115159
+             ],
+             [
+              -75.750093,
+              36.115159
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 51,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.749844,
+              36.114259
+             ],
+             [
+              -75.749844,
+              36.116259
+             ],
+             [
+              -75.747844,
+              36.116259
+             ],
+             [
+              -75.747844,
+              36.114259
+             ],
+             [
+              -75.749844,
+              36.114259
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 52,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.749595,
+              36.113358
+             ],
+             [
+              -75.749595,
+              36.115358
+             ],
+             [
+              -75.747595,
+              36.115358
+             ],
+             [
+              -75.747595,
+              36.113358
+             ],
+             [
+              -75.749595,
+              36.113358
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 53,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746894,
+              36.115993
+             ],
+             [
+              -75.746894,
+              36.117993
+             ],
+             [
+              -75.744894,
+              36.117993
+             ],
+             [
+              -75.744894,
+              36.115993
+             ],
+             [
+              -75.746894,
+              36.115993
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 89,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746624,
+              36.114914
+             ],
+             [
+              -75.746624,
+              36.116914
+             ],
+             [
+              -75.744624,
+              36.116914
+             ],
+             [
+              -75.744624,
+              36.114914
+             ],
+             [
+              -75.746624,
+              36.114914
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 90,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746354,
+              36.113834
+             ],
+             [
+              -75.746354,
+              36.115834
+             ],
+             [
+              -75.744354,
+              36.115834
+             ],
+             [
+              -75.744354,
+              36.113834
+             ],
+             [
+              -75.746354,
+              36.113834
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 91,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         }
+        ],
+        "type": "FeatureCollection"
+       },
+       "hover_style": {
+        "fillColor": "blue"
+       },
+       "name": "Selected ROIs"
+      }
+     },
+     "80b1d9eb9c9541acb364c57599bc6690": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "80ef1fe7b0fc4e22b1ebfa80da8cc70c": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletGeoJSONModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "data": {
+        "features": [
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.750093,
+              36.115159
+             ],
+             [
+              -75.750093,
+              36.117159
+             ],
+             [
+              -75.748093,
+              36.117159
+             ],
+             [
+              -75.748093,
+              36.115159
+             ],
+             [
+              -75.750093,
+              36.115159
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 51,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.749844,
+              36.114259
+             ],
+             [
+              -75.749844,
+              36.116259
+             ],
+             [
+              -75.747844,
+              36.116259
+             ],
+             [
+              -75.747844,
+              36.114259
+             ],
+             [
+              -75.749844,
+              36.114259
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 52,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.749595,
+              36.113358
+             ],
+             [
+              -75.749595,
+              36.115358
+             ],
+             [
+              -75.747595,
+              36.115358
+             ],
+             [
+              -75.747595,
+              36.113358
+             ],
+             [
+              -75.749595,
+              36.113358
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 53,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746894,
+              36.115993
+             ],
+             [
+              -75.746894,
+              36.117993
+             ],
+             [
+              -75.744894,
+              36.117993
+             ],
+             [
+              -75.744894,
+              36.115993
+             ],
+             [
+              -75.746894,
+              36.115993
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 89,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746624,
+              36.114914
+             ],
+             [
+              -75.746624,
+              36.116914
+             ],
+             [
+              -75.744624,
+              36.116914
+             ],
+             [
+              -75.744624,
+              36.114914
+             ],
+             [
+              -75.746624,
+              36.114914
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 90,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746354,
+              36.113834
+             ],
+             [
+              -75.746354,
+              36.115834
+             ],
+             [
+              -75.744354,
+              36.115834
+             ],
+             [
+              -75.744354,
+              36.113834
+             ],
+             [
+              -75.746354,
+              36.113834
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 91,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         }
+        ],
+        "type": "FeatureCollection"
+       },
+       "hover_style": {
+        "fillColor": "blue"
+       },
+       "name": "Selected ROIs"
+      }
+     },
+     "80fb4b4f73974397bbf3cf885bb39044": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "height": "auto",
+       "padding": "0px 0px 0px 4px",
+       "width": "auto"
+      }
+     },
+     "8108cc77379c42d98eb7e01e1efef207": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "(C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "OpenStreetMap.BlackAndWhite",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "http://a.tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png"
+      }
+     },
+     "8179cf15e6dd4093bef6b7f45a6ba8f0": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "height": "auto",
+       "padding": "0px 0px 0px 4px",
+       "width": "auto"
+      }
+     },
+     "81c6a9b3ca0e4e069607b56630e7faec": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.120973400280036,
+        -75.72170958108573
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_78799647211440a79ec3b241be5cbe63",
+       "title": "Location:(-75.72170958108573,36.120973400280036)"
+      }
+     },
+     "82462577d008409398558507b31ca869": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "82470d39356b469c9093ebe104207257": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_83aa022f969f402caa3d1ff17b928278",
+       "style": "IPY_MODEL_a4c02b9bb3334b28812cacbf80f2ab88",
+       "value": "Location:(-75.71821413656707,36.11372831916115)"
+      }
+     },
+     "82991695a3d546429fa58dbb7c8f8187": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5f867533aac64680af1fcc72f07538b7",
+       "style": "IPY_MODEL_d0e47241a1a94ee9b69fca24ef3ad707",
+       "value": "Location:(-75.74393002964503,36.12210187189958)"
+      }
+     },
+     "82cbdb77e9654fec88a4a4539ac91996": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+       "max_native_zoom": 18,
+       "max_zoom": 9,
+       "min_native_zoom": 0,
+       "name": "NASAGIBS.ModisAquaTrueColorCR",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Aqua_CorrectedReflectance_TrueColor/default//GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg"
+      }
+     },
+     "833407eb9acf4c0688de3993e5026210": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.11915767797389,
+        -75.72084495141614
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_f2c224446f114f47a5ea768ec1543522",
+       "title": "Location:(-75.72084495141614,36.11915767797389)"
+      }
+     },
+     "83aa022f969f402caa3d1ff17b928278": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "83e92842567e43d9b5d838e3417a36e7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "841c0af2d57e41edb9b4b2041d61585d": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletWMSLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "USGS",
+       "crs": {
+        "custom": false,
+        "name": "EPSG3857"
+       },
+       "format": "image/png",
+       "layers": "0",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "USGS Hydrography",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "format",
+        "layers",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "styles",
+        "tile_size",
+        "tms",
+        "transparent",
+        "uppercase"
+       ],
+       "transparent": true,
+       "url": "https://basemap.nationalmap.gov/arcgis/services/USGSHydroCached/MapServer/WMSServer?"
+      }
+     },
+     "843f154dedfe491fa90c5a28fb1f429d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_38a4f236babd4a2bb3f8e8ad48c2b200",
+       "style": "IPY_MODEL_1d19729d0f0f4c428082904f3eb72c92",
+       "value": "Location:(-75.74616361588207,36.11807219352825)"
+      }
+     },
+     "847a6d162f094dfda44d27ef6caabf5f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_c25de9e1e9104836972cb9e5294cefbd",
+       "style": "IPY_MODEL_c0edac7f69f54535b9cac784d0cc46e6",
+       "value": "Location:(-75.72255641786006,36.122797425318886)"
+      }
+     },
+     "857a2b8e7eff4122a06553adb223b5ab": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Kaartgegevens (C) Kadaster",
+       "max_native_zoom": 18,
+       "max_zoom": 19,
+       "min_native_zoom": 0,
+       "name": "nlmaps.standaard",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/standaard/EPSG:3857/{z}/{x}/{y}.png"
+      }
+     },
+     "85aa11b5927d40208f7be8cf79395449": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletGeoJSONModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "data": {
+        "features": [
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.749844,
+              36.114259
+             ],
+             [
+              -75.749844,
+              36.116259
+             ],
+             [
+              -75.747844,
+              36.116259
+             ],
+             [
+              -75.747844,
+              36.114259
+             ],
+             [
+              -75.749844,
+              36.114259
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 52,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.749595,
+              36.113358
+             ],
+             [
+              -75.749595,
+              36.115358
+             ],
+             [
+              -75.747595,
+              36.115358
+             ],
+             [
+              -75.747595,
+              36.113358
+             ],
+             [
+              -75.749595,
+              36.113358
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 53,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746624,
+              36.114914
+             ],
+             [
+              -75.746624,
+              36.116914
+             ],
+             [
+              -75.744624,
+              36.116914
+             ],
+             [
+              -75.744624,
+              36.114914
+             ],
+             [
+              -75.746624,
+              36.114914
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 90,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746354,
+              36.113834
+             ],
+             [
+              -75.746354,
+              36.115834
+             ],
+             [
+              -75.744354,
+              36.115834
+             ],
+             [
+              -75.744354,
+              36.113834
+             ],
+             [
+              -75.746354,
+              36.113834
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 91,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         }
+        ],
+        "type": "FeatureCollection"
+       },
+       "hover_style": {
+        "fillColor": "blue"
+       },
+       "name": "Selected ROIs"
+      }
+     },
+     "85ece48972bc4ddcb547615a994a08ad": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_dafd8ac0f19c4c2a979b8aebfc126ace",
+       "style": "IPY_MODEL_453b6c17241a4e54877532846889dd2d",
+       "value": "Location:(-75.74909298584559,36.11615948651872)"
+      }
+     },
+     "86c3209546aa465fbaeeb37760d099ce": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2021</a>",
+       "max_native_zoom": 18,
+       "max_zoom": 15,
+       "min_native_zoom": 0,
+       "name": "Strava.Run",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://heatmap-external-a.strava.com/tiles/run/bluered/{z}/{x}/{y}.png"
+      }
+     },
+     "87441e20b5e0461d9bfb4b1246d82ce9": {
+      "model_module": "@here/map-widget-for-jupyter",
+      "model_module_version": "^1.1.3",
+      "model_name": "DefaultLayersModel",
+      "state": {
+       "_model_module": "@here/map-widget-for-jupyter",
+       "_model_module_version": "^1.1.3",
+       "_view_count": null,
+       "_view_module": "@here/map-widget-for-jupyter",
+       "_view_module_version": "^1.1.3",
+       "layer_name": "raster.terrain.base",
+       "ppi": null
+      }
+     },
+     "876421906008418ba1481f73f6bdb706": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "(C) OpenStreetMap contributors (C) CARTO",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "CartoDB.VoyagerOnlyLabels",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://a.basemaps.cartocdn.com/rastertiles/voyager_only_labels/{z}/{x}/{y}.png"
+      }
+     },
+     "87a205e6fb874058a9346819876cc881": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.10773667086335,
+        -75.71458987236348
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_8e3882f591084e85935164d8e0d16520",
+       "title": "Location:(-75.71458987236348,36.10773667086335)"
+      }
+     },
+     "87de96ac86a04a9fb1e66aa4af0306df": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "89254a7fba6040d2aa1a6cddb61fec6a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_160a15dcb6a9455a9a8d542bc81ebd8f",
+       "style": "IPY_MODEL_4a2aeaf42761491a95c1e3f2d8bc3719",
+       "value": "Location:(-75.74575681562084,36.10163174252044)"
+      }
+     },
+     "896721fc5d0b475d9a4104e5cca45e23": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8981008afd2e407ba361719563b3fbea": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_b2c9ecc40e5348389b6a2641b3e0de0b",
+       "style": "IPY_MODEL_1b571e65933e4ebd9022e7ee21bed689",
+       "value": "Location:(-75.70794371391897,36.09535859916541)"
+      }
+     },
+     "89f670f2453e46abb9af1881e2d44fc6": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Tiles courtesy of OpenStreetMap Sweden -- Map data (C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "Hydda.Full",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://a.tile.openstreetmap.se/hydda/full/{z}/{x}/{y}.png"
+      }
+     },
+     "8ae05c6a6ebb405bbd5cfc47df9edf07": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.118844682723626,
+        -75.7498974842412
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_f4c212480ee74ade9bdd45b6a823b176",
+       "title": "Location:(-75.7498974842412,36.118844682723626)"
+      }
+     },
+     "8c644bfb1a874698924f1fec3eb8bc82": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8cdec17b3a5e47ba93487c700fbc718a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8d3ce35f593a404597c88df805f8a400": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "8d722b0b7ed74aa482bd47df7bb6d95b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8df4a45ca59a4313b88a4deac113a7ee": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.12006553912696,
+        -75.72127726625094
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_58f8d568a989487ab772cc237f0cfc59",
+       "title": "Location:(-75.72127726625094,36.12006553912696)"
+      }
+     },
+     "8e3882f591084e85935164d8e0d16520": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6c91489331784ed5b4fad1940acfd4fb",
+       "style": "IPY_MODEL_0b1ef54d05024fcf9c15e11abb7c20f5",
+       "value": "Location:(-75.71458987236348,36.10773667086335)"
+      }
+     },
+     "8e5eb24759764a6d9cba136935e4b9d9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "height": "auto",
+       "padding": "0px 0px 0px 4px",
+       "width": "auto"
+      }
+     },
+     "8f02b740ad3c47a09341ce16b3ec1ff2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "height": "auto",
+       "padding": "0px 0px 0px 4px",
+       "width": "auto"
+      }
+     },
+     "8f410d3c94f44173adba94c33e367910": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Google",
+       "max_native_zoom": 18,
+       "max_zoom": 22,
+       "min_native_zoom": 0,
+       "name": "Google Terrain",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://mt1.google.com/vt/lyrs=p&x={x}&y={y}&z={z}"
+      }
+     },
+     "8f4a3e6fc9bc42ee806660dd1a5726bc": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "grid_gap": "1px 1px",
+       "grid_template_columns": "32px 32px 32px ",
+       "grid_template_rows": "32px 32px 32px 32px 32px ",
+       "padding": "5px",
+       "width": "109px"
+      }
+     },
+     "8f659a2866844fc09bce5a45207377eb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "8f9fe98f7db9416ab04e501f0a5384aa": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9079558744314c04be34c55a0835f68d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "909a098203ef406ca67c5a8921b16e1d": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.10987605829631,
+        -75.74727096896378
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_1af6b36ae97045fab1defeea35609c7e",
+       "title": "Location:(-75.74727096896378,36.10987605829631)"
+      }
+     },
+     "90d53be96e73442b88a3d92046245743": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_cc9ab222aa7741e0a4857e24715b9281",
+       "style": "IPY_MODEL_a7d65295d25c4a96bb7e77dc3d7cfd4f",
+       "value": "Location:(-75.74535414903995,36.114834326159816)"
+      }
+     },
+     "9122238ca9ee432bb9ac6651e52e6529": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "915bc3fb4ce041b4be0f43cf6d18be00": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map data: (C) OpenStreetMap contributors | Map style: (C) waymarkedtrails.org (CC-BY-SA)",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "WaymarkedTrails.mtb",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://tile.waymarkedtrails.org/mtb/{z}/{x}/{y}.png"
+      }
+     },
+     "915c1c17143b4220858adfee64e91359": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.126405,
+        -75.74903784076923
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_d6d8b599ca4a44279cf5f847ce37447e",
+       "title": "Location:(-75.74903784076923,36.126405)"
+      }
+     },
+     "9183a1408c7e4b43af0492d69ac20a47": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "91d5eb5d881d4a46b89aaaf814e3486e": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
+       "max_native_zoom": 18,
+       "max_zoom": 9,
+       "min_native_zoom": 0,
+       "name": "NASAGIBS.ModisTerraBands367CR",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/MODIS_Terra_CorrectedReflectance_Bands367/default//GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg"
+      }
+     },
+     "91dbeffa8f9b4fceba8e31a20f497427": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_aeffd4603e604ac09d09f7101fb369d8",
+       "style": "IPY_MODEL_b9f6763eaeb046b38681d765e211078c",
+       "value": "Location:(-75.7456740603812,36.10070073468595)"
+      }
+     },
+     "92f1371013a847a19e0ea31e92398f4d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "93717828a3dd493aaf28f5ec982c9454": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "93de4c3726bc4c34a1d2c8b996bcf9c3": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map data: (C) OpenStreetMap contributors | Map style: (C) SafeCast (CC-BY-SA)",
+       "max_native_zoom": 18,
+       "max_zoom": 16,
+       "min_native_zoom": 0,
+       "name": "SafeCast",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://s3.amazonaws.com/te512.safecast.org/{z}/{x}/{y}.png"
+      }
+     },
+     "93f734884768437abdb66c8bfd73bc59": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "height": "auto",
+       "padding": "0px 0px 0px 4px",
+       "width": "auto"
+      }
+     },
+     "94085e32206b49f08f481830507265e8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_322a05486c524d4ab1fc2d2f46456b3c",
+       "style": "IPY_MODEL_5612b60fc3c04c0ebf0ac826ade9824d",
+       "value": "Location:(-75.75177306956394,36.1239457459644)"
+      }
+     },
+     "94556bd91ecd46df9c2450b8bed6d1c6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "94b6d2eb9386446499e13ea6c5d75576": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.11435777933147,
+        -75.74859464130445
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_cc62bfc510de4224887019b1eefc009e",
+       "title": "Location:(-75.74859464130445,36.11435777933147)"
+      }
+     },
+     "94d376863ca849df81efcc637682821a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9517fb2a70f144cf9a6aff382305e2cb": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Justice Map",
+       "max_native_zoom": 18,
+       "max_zoom": 22,
+       "min_native_zoom": 0,
+       "name": "JusticeMap.americanIndian",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://www.justicemap.org/tile/county/indian/{z}/{x}/{y}.png"
+      }
+     },
+     "95293ba1e9cc4106930cfdcd0746a8a8": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "(C) OpenStreetMap contributors, Tiles courtesy of Breton OpenStreetMap Team",
+       "max_native_zoom": 18,
+       "max_zoom": 19,
+       "min_native_zoom": 0,
+       "name": "OpenStreetMap.BZH",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://tile.openstreetmap.bzh/br/{z}/{x}/{y}.png"
+      }
+     },
+     "958a059b3b0644ef9211e83a75941d43": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "95add1af322f48f89d88db2eb2603489": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "CyclOSM | Map data: (C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "CyclOSM",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://a.tile-cyclosm.openstreetmap.fr/cyclosm/{z}/{x}/{y}.png"
+      }
+     },
+     "95d123fa142f4ae39d31097dcf5e8515": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.11807219352825,
+        -75.74616361588207
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_843f154dedfe491fa90c5a28fb1f429d",
+       "title": "Location:(-75.74616361588207,36.11807219352825)"
+      }
+     },
+     "96188ff47c1f443b87d1c4c5348845a2": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "961b139ce35d412fbd128c2cb3be3bde": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "National Library of Scotland Historic Maps",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "NLS",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://nls-0.tileserver.com/nls/{z}/{x}/{y}.jpg"
+      }
+     },
+     "962436160fe848179a529ef50ee00fcb": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.10961522873192,
+        -75.74345433291064
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_018dcdfa31c44941b5bd3a7274e00594",
+       "title": "Location:(-75.74345433291064,36.10961522873192)"
+      }
+     },
+     "96402a9bdaf34956a2a5b811c50a554b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "966fc50e63e248c8be36ad63951326a8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_c16d8fdf8b3244b289d3c8c233d126a2",
+       "style": "IPY_MODEL_a2c0afbe68e14f478d42ca247bac8d4d",
+       "value": "Location:(-75.74600508133976,36.104424766023904)"
+      }
+     },
+     "967add8cbd404605b2406ba000206f74": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a68ffe5bad234eef920a59318ab15b7f",
+       "style": "IPY_MODEL_60e32f5454b24468892885dfaef6c1d8",
+       "value": "Location:(-75.74420466590242,36.111708630930856)"
+      }
+     },
+     "976eef18f8034eb7ad4e500e5eb6ac44": {
+      "model_module": "@here/map-widget-for-jupyter",
+      "model_module_version": "^1.1.3",
+      "model_name": "DefaultLayersModel",
+      "state": {
+       "_model_module": "@here/map-widget-for-jupyter",
+       "_model_module_version": "^1.1.3",
+       "_view_count": null,
+       "_view_module": "@here/map-widget-for-jupyter",
+       "_view_module_version": "^1.1.3",
+       "ppi": null
+      }
+     },
+     "97ca6b71f1d149f29923aa4346a136fa": {
+      "model_module": "@here/map-widget-for-jupyter",
+      "model_module_version": "^1.1.3",
+      "model_name": "DefaultLayersModel",
+      "state": {
+       "_model_module": "@here/map-widget-for-jupyter",
+       "_model_module_version": "^1.1.3",
+       "_view_count": null,
+       "_view_module": "@here/map-widget-for-jupyter",
+       "_view_module_version": "^1.1.3",
+       "layer_name": "raster.normal.xbasenight",
+       "ppi": null
+      }
+     },
+     "982c11f3e0954844a9d46d58fbc665eb": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletGeoJSONModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "data": {
+        "features": [
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746894,
+              36.115993
+             ],
+             [
+              -75.746894,
+              36.117993
+             ],
+             [
+              -75.744894,
+              36.117993
+             ],
+             [
+              -75.744894,
+              36.115993
+             ],
+             [
+              -75.746894,
+              36.115993
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 89,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         }
+        ],
+        "type": "FeatureCollection"
+       },
+       "hover_style": {
+        "fillColor": "blue"
+       },
+       "name": "Selected ROIs"
+      }
+     },
+     "984e44404e6449bda1f87d867ac912eb": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.122797425318886,
+        -75.72255641786006
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_847a6d162f094dfda44d27ef6caabf5f",
+       "title": "Location:(-75.72255641786006,36.122797425318886)"
+      }
+     },
+     "98afa40622884cafa1786a3dfb938775": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9991236ebd224e7fa41ad7c3a8c6def4": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "(C) Stadia Maps, (C) OpenMapTiles (C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "Stadia.Outdoors",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://tiles.stadiamaps.com/tiles/outdoors/{z}/{x}/{y}.png"
+      }
+     },
+     "9c90bf3aebae4daa95af9faeed69fcb7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9cbcab14b24241caad14ae77e3b85325": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9d119dae02864db99a8432dbcca5f1b7": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9dd6c8b177d94611a8f92057210c9d9d": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "(C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "max_zoom": 15,
+       "min_native_zoom": 0,
+       "name": "HikeBike.HillShading",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://tiles.wmflabs.org/hillshading/{z}/{x}/{y}.png"
+      }
+     },
+     "9df19f445fb64ba7a0c487920159b220": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9e0f5479def74789a6459b82024f2bbd": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "(C) Stadia Maps, (C) OpenMapTiles (C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "Stadia.OSMBright",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://tiles.stadiamaps.com/tiles/osm_bright/{z}/{x}/{y}.png"
+      }
+     },
+     "9e9b0ac2db3e4ec3a002e0be5b9ed1ca": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "9e9c824154244361a496802bd0529ec0": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletWMSLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "MRLC",
+       "crs": {
+        "custom": false,
+        "name": "EPSG3857"
+       },
+       "format": "image/png",
+       "layers": "NLCD_2008_Land_Cover_L48",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "NLCD 2008 CONUS Land Cover",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "format",
+        "layers",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "styles",
+        "tile_size",
+        "tms",
+        "transparent",
+        "uppercase"
+       ],
+       "transparent": true,
+       "url": "https://www.mrlc.gov/geoserver/mrlc_display/NLCD_2008_Land_Cover_L48/wms?"
+      }
+     },
+     "9eeec829c1a140e49bb754702ed4337c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "9f28b63a50c647cb8ac9746f1d528b3d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "_view_count": 4,
+       "children": [
+        "IPY_MODEL_afea37882b984eeaabc97e32f0d0563b"
+       ],
+       "layout": "IPY_MODEL_a5572a3ef5fd4d1ab6552b219891c326"
+      }
+     },
+     "9fc5d0461ebc4429b5b4727793f02859": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.091104,
+        -75.742208635
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_666967d882204115aec2be88986d439c",
+       "title": "Location:(-75.742208635,36.091104)"
+      }
+     },
+     "9ff8dcb052b249e1893b3c334df72bd4": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.09979789465861,
+        -75.74546582382159
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_bfa5c14870ce4210a1a559c10bc5cd32",
+       "title": "Location:(-75.74546582382159,36.09979789465861)"
+      }
+     },
+     "a0017cae4b9b4e4094171de2f2fa3fa5": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletWMSLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "MRLC",
+       "crs": {
+        "custom": false,
+        "name": "EPSG3857"
+       },
+       "format": "image/png",
+       "layers": "NLCD_2016_Land_Cover_L48",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "NLCD 2016 CONUS Land Cover",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "format",
+        "layers",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "styles",
+        "tile_size",
+        "tms",
+        "transparent",
+        "uppercase"
+       ],
+       "transparent": true,
+       "url": "https://www.mrlc.gov/geoserver/mrlc_display/NLCD_2016_Land_Cover_L48/wms?"
+      }
+     },
+     "a032933ad99c4b6a9ed0af9dfa01a91d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "height": "auto",
+       "padding": "0px 0px 0px 4px",
+       "width": "auto"
+      }
+     },
+     "a03aba49b7814edb9d4f991a3bcbaa1b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_d630687dff634a8e9b79296d49793f20",
+       "style": "IPY_MODEL_d800152693454dd0a229b979555ff511",
+       "value": "Location:(-75.743753467199,36.09545357866556)"
+      }
+     },
+     "a059931af27040df85c65031fb9ca154": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5e3918f7fcb54a2899543555daf89296",
+       "style": "IPY_MODEL_79b0a9ed1c4748c8806178fb13f6dfc8",
+       "value": "Location:(-75.74562397132065,36.11591361528262)"
+      }
+     },
+     "a06a89d6d18d4db7bee05f908153984d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "height": "auto",
+       "padding": "0px 0px 0px 4px",
+       "width": "auto"
+      }
+     },
+     "a0e7005fdcb6463da78a0c5eee1276ae": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a0fd52eab98c414cb429ffba8c3f3869": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a1104be85f7a4b47a056a68f3071fb03": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.118249816820814,
+        -75.72041263658134
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_0bfae8a58ccd4adc9c5093c4187612e2",
+       "title": "Location:(-75.72041263658134,36.118249816820814)"
+      }
+     },
+     "a19c6c2a01144a1381558e810c537392": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5fde9a4ad09c44199b7408953cfc03b4",
+       "style": "IPY_MODEL_f914c16de07e49d4baf5e2c8f38917f1",
+       "value": "Location:(-75.74233401041278,36.11565080735296)"
+      }
+     },
+     "a2c0afbe68e14f478d42ca247bac8d4d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a2f1d1fe96a64e83930053cd4195deed": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a3860715912b4f2e80ad695173e2336a": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "(C) OpenStreetMap contributors (C) CARTO",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "CartoDB.PositronNoLabels",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://a.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png"
+      }
+     },
+     "a3b85387bdf04203b52dc19f72aaa4da": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "OpenStreetMap",
+       "max_native_zoom": 18,
+       "max_zoom": 22,
+       "min_native_zoom": 0,
+       "name": "OpenStreetMap",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ]
+      }
+     },
+     "a3c0d9333ada465784228b3dc8608e05": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.111708630930856,
+        -75.74420466590242
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_967add8cbd404605b2406ba000206f74",
+       "title": "Location:(-75.74420466590242,36.111708630930856)"
+      }
+     },
+     "a435d6196b474560915bf7baf62972e8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a43e2fee55ff473c870fef88393fbc13": {
+      "model_module": "@here/map-widget-for-jupyter",
+      "model_module_version": "^1.1.3",
+      "model_name": "DefaultLayersModel",
+      "state": {
+       "_model_module": "@here/map-widget-for-jupyter",
+       "_model_module_version": "^1.1.3",
+       "_view_count": null,
+       "_view_module": "@here/map-widget-for-jupyter",
+       "_view_module_version": "^1.1.3",
+       "layer_name": "raster.normal.base",
+       "ppi": null
+      }
+     },
+     "a4baa23691d44967ba21eef93dd47480": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Geoportail France",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "GeoportailFrance.parcels",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://wxs.ign.fr/choisirgeoportail/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE=PCI vecteur&TILEMATRIXSET=PM&FORMAT=image/png&LAYER=CADASTRALPARCELS.PARCELLAIRE_EXPRESS&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}"
+      }
+     },
+     "a4c02b9bb3334b28812cacbf80f2ab88": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a4ce55870dd044ff993ef534e7f77b6b": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.1223893500195,
+        -75.74724290500487
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_dc68d2a27a6a48b6bcd801ef1b0bb101",
+       "title": "Location:(-75.74724290500487,36.1223893500195)"
+      }
+     },
+     "a4db6ffacdae497db9c4b32627ce788b": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "![](https://docs.onemap.sg/maps/images/oneMap64-01.png) New OneMap | Map data (C) contributors, Singapore Land Authority",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "OneMapSG.Original",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://maps-a.onemap.sg/v3/Original/{z}/{x}/{y}.png"
+      }
+     },
+     "a52fb643557a4adf9bc26133668e69a3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a5351931dad84154b2811a62cf1c3c0b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ToggleButtonModel",
+      "state": {
+       "button_style": "primary",
+       "icon": "folder-open",
+       "layout": "IPY_MODEL_f1c14ac4983742f1964cfa73be207f9e",
+       "style": "IPY_MODEL_a53cb1cdff1a4459b0d1f723384672eb",
+       "tooltip": "Open local vector/raster data"
+      }
+     },
+     "a53cb1cdff1a4459b0d1f723384672eb": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a5572a3ef5fd4d1ab6552b219891c326": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a57108d6b2f94565a6004222753c9013": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a5962110784442559813ad900f50901e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_3c342c46ed314dcfbf2c72fa37a74dc5",
+       "style": "IPY_MODEL_634fe2f4fbf84c68be1f1bc7a4e24ccc",
+       "value": "Location:(-75.74583957086048,36.10256275035493)"
+      }
+     },
+     "a59df042f3624d359415cc754d6f5a84": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Google",
+       "max_native_zoom": 18,
+       "max_zoom": 22,
+       "min_native_zoom": 0,
+       "name": "Google Maps",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://mt1.google.com/vt/lyrs=m&x={x}&y={y}&z={z}"
+      }
+     },
+     "a66730019d2a4b70ae9b7857e52575a9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a67f3a2239934bb480163454abcbac86": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a687033714ad4dea941b6944be940912": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors",
+       "base": true,
+       "max_native_zoom": 18,
+       "max_zoom": 19,
+       "min_native_zoom": 0,
+       "min_zoom": 1,
+       "name": "OpenStreetMap",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      }
+     },
+     "a68ffe5bad234eef920a59318ab15b7f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a75f4aee335f4e458a3c879e997daa1c": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.111261348400646,
+        -75.7164947699845
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_b082596c4acf4e35953fd2eb87722b5e",
+       "title": "Location:(-75.7164947699845,36.111261348400646)"
+      }
+     },
+     "a7caadf1f3c74195b62eac7b22fca61a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a7d65295d25c4a96bb7e77dc3d7cfd4f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "a831bc6150d84d5fa43ded7b220c7728": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map data: (C) OpenStreetMap contributors | Map style: (C) waymarkedtrails.org (CC-BY-SA)",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "WaymarkedTrails.riding",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://tile.waymarkedtrails.org/riding/{z}/{x}/{y}.png"
+      }
+     },
+     "a831ea1113ed4d40a27f9cc57edc8138": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_ad938948c8b04e56bc687cd3382e67cb",
+       "style": "IPY_MODEL_03cae58267b441fe82977b30138319fa",
+       "value": "Location:(-75.7441579317614,36.09629621288948)"
+      }
+     },
+     "a83dc2f8fea741ddb35a284a921d92fa": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "width": "500px"
+      }
+     },
+     "a8e1a3b99bc0439eb05b678d2b129cd5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "a938f87e06b34d648c9ab4f3c553fa65": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_0eb25bb888ed492eb006ec0d1d465c15",
+       "style": "IPY_MODEL_00af53b29e414186b4167fd097c51917",
+       "value": "Location:(-75.74648203893831,36.10622622282646)"
+      }
+     },
+     "a9b2928b22f34fd59ed8996b7acdfa52": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_f6144c08db7b4c10ab426bc8c308773f",
+       "style": "IPY_MODEL_fe9fe923fe37452ab93f6d7402bce99a",
+       "value": "Location:(-75.72297448037082,36.12371193706116)"
+      }
+     },
+     "ab4328cd37694dcbb22fc623ca7ec74e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ab51aeef0bc840b79de5ea5c7515f477": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "abadc1574c0b4d36afce5fc72b3d58c6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ad13758cba4e4f898409395aa7299ce6": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "height": "auto",
+       "padding": "0px 0px 0px 4px",
+       "width": "auto"
+      }
+     },
+     "ad938948c8b04e56bc687cd3382e67cb": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "adab3702e4124757b99b4d381b7dc940": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_3f1e4ac0b2b54dbb9a7c68fa99b7f40a",
+        "IPY_MODEL_afea37882b984eeaabc97e32f0d0563b"
+       ],
+       "layout": "IPY_MODEL_0c3dc035990544eda0c5bf70c100a5b1"
+      }
+     },
+     "adc7eec9d97e4cf194a4b68827464fae": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "adebc26e4185465b83d37aec5992a4b5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "aefefb887adc4542ac813a1258d06381": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.094507679332324,
+        -75.70740794957962
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_44785b1f02d443ad9cfc671ca913d85a",
+       "title": "Location:(-75.70740794957962,36.094507679332324)"
+      }
+     },
+     "aeffd4603e604ac09d09f7101fb369d8": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "af05e5f52b2e4f6cb075b6cfd356b52d": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.119983148429974,
+        -75.74325062866691
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_c71ad173c7d948e5818ba215cacf9b40",
+       "title": "Location:(-75.74325062866691,36.119983148429974)"
+      }
+     },
+     "af47addb40c8485b8db8d787ccf787e8": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.11591361528262,
+        -75.74562397132065
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_a059931af27040df85c65031fb9ca154",
+       "title": "Location:(-75.74562397132065,36.11591361528262)"
+      }
+     },
+     "afacfa21d7424d8389b572f444c8732d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_656aef883ce941cf967abc513c740479",
+       "style": "IPY_MODEL_8d3ce35f593a404597c88df805f8a400",
+       "value": "Location:(-75.74691700575555,36.10804125599071)"
+      }
+     },
+     "afea37882b984eeaabc97e32f0d0563b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ToggleButtonModel",
+      "state": {
+       "icon": "wrench",
+       "layout": "IPY_MODEL_6e657a8f395a43328a2d27de28d17a65",
+       "style": "IPY_MODEL_3aac07e83163449f8939c27ab238f6e4",
+       "tooltip": "Toolbar"
+      }
+     },
+     "b063155a9c744c2187dcd9febcf80ced": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.12104309057717,
+        -75.74358848728296
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_d1de76aec63d4be9b5ff6748f329d1ee",
+       "title": "Location:(-75.74358848728296,36.12104309057717)"
+      }
+     },
+     "b07797a3255148ca8232f15e82cbcfe7": {
+      "model_module": "@here/map-widget-for-jupyter",
+      "model_module_version": "^1.1.3",
+      "model_name": "DefaultLayersModel",
+      "state": {
+       "_model_module": "@here/map-widget-for-jupyter",
+       "_model_module_version": "^1.1.3",
+       "_view_count": null,
+       "_view_module": "@here/map-widget-for-jupyter",
+       "_view_module_version": "^1.1.3",
+       "layer_name": "raster.normal.xbase",
+       "ppi": null
+      }
+     },
+     "b082596c4acf4e35953fd2eb87722b5e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_3291aa221a8145d188f4cfebe25a9c67",
+       "style": "IPY_MODEL_0e6462ca2127411b891d4ceb62e39991",
+       "value": "Location:(-75.7164947699845,36.111261348400646)"
+      }
+     },
+     "b0e45a3842d04c41a540458b1f8e09c8": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.11273660498248,
+        -75.7446300344755
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_375ae7c236924b5c8840c3a3004a4521",
+       "title": "Location:(-75.7446300344755,36.11273660498248)"
+      }
+     },
+     "b1594fe294674102a3398cbf312c3515": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b15ae74c7b5649ae8df4c32847b9a277": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.11973139666612,
+        -75.75019305555537
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_51fee07610964c9ea860679a761b63ba",
+       "title": "Location:(-75.75019305555537,36.11973139666612)"
+      }
+     },
+     "b163dc6cbfa846e3b6e87f949323bdc3": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "![](https://docs.onemap.sg/maps/images/oneMap64-01.png) New OneMap | Map data (C) contributors, Singapore Land Authority",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "OneMapSG.LandLot",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://maps-a.onemap.sg/v3/LandLot/{z}/{x}/{y}.png"
+      }
+     },
+     "b1a5888546424bb2899df98ff02d6eda": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b1e09eed06e544b799922f32825f7d89": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+       "max_native_zoom": 18,
+       "max_zoom": 9,
+       "min_native_zoom": 0,
+       "name": "NASAGIBS.ModisTerraBands721CR",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Terra_CorrectedReflectance_Bands721/default//GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg"
+      }
+     },
+     "b22c6b54d17f47378e36a90978505bce": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.09365675949925,
+        -75.70687218524027
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_0076ec681ec04968b826fa45867081e4",
+       "title": "Location:(-75.70687218524027,36.09365675949925)"
+      }
+     },
+     "b2932cf03bfc4433898e8a4477df5aa8": {
+      "model_module": "@here/map-widget-for-jupyter",
+      "model_module_version": "^1.1.3",
+      "model_name": "DefaultLayersModel",
+      "state": {
+       "_model_module": "@here/map-widget-for-jupyter",
+       "_model_module_version": "^1.1.3",
+       "_view_count": null,
+       "_view_module": "@here/map-widget-for-jupyter",
+       "_view_module_version": "^1.1.3",
+       "layer_name": "raster.satellite.labels",
+       "ppi": null
+      }
+     },
+     "b2c9ecc40e5348389b6a2641b3e0de0b": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b30f15deabe14d3e9648176230557be1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_2b86f018d89c47f98920431a2c2a0c6c",
+       "style": "IPY_MODEL_b87b4ee427f44df08e270e35fff6cadd",
+       "value": "Location:(-75.71407724635286,36.10687161447046)"
+      }
+     },
+     "b452b81bd4ae49a2adfa7f061b312b17": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b4a6d6874ce34e40b720feac68dcdb90": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b5b8e241cfb04837a5d97f94ad3e1ee6": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMapStyleModel",
+      "state": {
+       "_model_module_version": "^0.15.0"
+      }
+     },
+     "b64f7af092cc4a7c9fc8c78641446d3e": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map tiles by Stamen Design, CC BY 3.0 -- Map data (C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "Stamen.TopOSMFeatures",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://stamen-tiles-a.a.ssl.fastly.net/toposm-features/{z}/{x}/{y}.png"
+      }
+     },
+     "b6b1d754e7624100af6de767aaa669b9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_e243f9e61e064aea9e872d467ef67eed",
+       "style": "IPY_MODEL_7f1944dd040a458fb50c6ed10d1647f5",
+       "value": "Location:(-75.71356462034225,36.10600655807756)"
+      }
+     },
+     "b6c9e984a5514770902a479f4530eacf": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletGeoJSONModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "data": {
+        "features": [
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.749844,
+              36.114259
+             ],
+             [
+              -75.749844,
+              36.116259
+             ],
+             [
+              -75.747844,
+              36.116259
+             ],
+             [
+              -75.747844,
+              36.114259
+             ],
+             [
+              -75.749844,
+              36.114259
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 52,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.749595,
+              36.113358
+             ],
+             [
+              -75.749595,
+              36.115358
+             ],
+             [
+              -75.747595,
+              36.115358
+             ],
+             [
+              -75.747595,
+              36.113358
+             ],
+             [
+              -75.749595,
+              36.113358
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 53,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746894,
+              36.115993
+             ],
+             [
+              -75.746894,
+              36.117993
+             ],
+             [
+              -75.744894,
+              36.117993
+             ],
+             [
+              -75.744894,
+              36.115993
+             ],
+             [
+              -75.746894,
+              36.115993
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 89,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746624,
+              36.114914
+             ],
+             [
+              -75.746624,
+              36.116914
+             ],
+             [
+              -75.744624,
+              36.116914
+             ],
+             [
+              -75.744624,
+              36.114914
+             ],
+             [
+              -75.746624,
+              36.114914
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 90,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746354,
+              36.113834
+             ],
+             [
+              -75.746354,
+              36.115834
+             ],
+             [
+              -75.744354,
+              36.115834
+             ],
+             [
+              -75.744354,
+              36.113834
+             ],
+             [
+              -75.746354,
+              36.113834
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 91,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         }
+        ],
+        "type": "FeatureCollection"
+       },
+       "hover_style": {
+        "fillColor": "blue"
+       },
+       "name": "Selected ROIs"
+      }
+     },
+     "b7a8ed7dcca44b1ea9a8d52e2f5b3789": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletWMSLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "MRLC",
+       "crs": {
+        "custom": false,
+        "name": "EPSG3857"
+       },
+       "format": "image/png",
+       "layers": "NLCD_2006_Land_Cover_L48",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "NLCD 2006 CONUS Land Cover",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "format",
+        "layers",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "styles",
+        "tile_size",
+        "tms",
+        "transparent",
+        "uppercase"
+       ],
+       "transparent": true,
+       "url": "https://www.mrlc.gov/geoserver/mrlc_display/NLCD_2006_Land_Cover_L48/wms?"
+      }
+     },
+     "b85ba37376f640bdba915318700f243c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b87a1715fddc4be191d661e705189645": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMapStyleModel",
+      "state": {
+       "_model_module_version": "^0.15.0"
+      }
+     },
+     "b87b4ee427f44df08e270e35fff6cadd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b87f53c3abba4a4296fae45d5aea1aca": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_36621d27185349ca9a6fa9efbf7cdf48",
+       "style": "IPY_MODEL_a0fd52eab98c414cb429ffba8c3f3869",
+       "value": "Location:(-75.70847947825831,36.09620951899849)"
+      }
+     },
+     "b8ab558997d4407cab4f49c89f7b34a9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b8cf3ff451f34e13b43e53b05dd79a59": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b980bda5427442d7a494956f9e1026a4": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.103493758189416,
+        -75.74592232610013
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_18e05b666c554a95836cc31253428256",
+       "title": "Location:(-75.74592232610013,36.103493758189416)"
+      }
+     },
+     "b9c0c6d7bdd24ee49e434e312771df44": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "b9d9ed6e55874155985aedfc47402b9d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "b9f6763eaeb046b38681d765e211078c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ba8180f8de014ea897484224c0347e1e": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (ESDIS) with funding provided by NASA/HQ.",
+       "max_native_zoom": 18,
+       "max_zoom": 8,
+       "min_native_zoom": 0,
+       "name": "NASAGIBS.ViirsEarthAtNight2012",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/VIIRS_CityLights_2012/default//GoogleMapsCompatible_Level8/{z}/{y}/{x}.jpg"
+      }
+     },
+     "badc4d8c9f854f0eaf3fc4310aa83724": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "bb81c333e48649ba93749ae50f67c589": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_1bab3e7161e948f2aac0e1471da2db55",
+       "style": "IPY_MODEL_e9183320b964479abbe6d54ed1357157",
+       "value": "Location:(-75.74620989409237,36.10533204096554)"
+      }
+     },
+     "bb82394f460244f08974d6d62209fe4c": {
+      "model_module": "@here/map-widget-for-jupyter",
+      "model_module_version": "^1.1.3",
+      "model_name": "DefaultLayersModel",
+      "state": {
+       "_model_module": "@here/map-widget-for-jupyter",
+       "_model_module_version": "^1.1.3",
+       "_view_count": null,
+       "_view_module": "@here/map-widget-for-jupyter",
+       "_view_module_version": "^1.1.3",
+       "layer_name": "raster.satellite.base",
+       "ppi": null
+      }
+     },
+     "bb8ea54d89fa48bdb1890a4de5df311d": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.09804629453726,
+        -75.70928943833887
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_02a0ffec18f142198f3a8d32b58aa890",
+       "title": "Location:(-75.70928943833887,36.09804629453726)"
+      }
+     },
+     "bbb67225841d46d4b36eca9e9656b1ec": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ToggleButtonModel",
+      "state": {
+       "button_style": "primary",
+       "icon": "globe",
+       "layout": "IPY_MODEL_8179cf15e6dd4093bef6b7f45a6ba8f0",
+       "style": "IPY_MODEL_1cad066a28cf493db589f82af0c3cb8d",
+       "tooltip": "Split-panel map"
+      }
+     },
+     "bbda8e4c2eaf4cd2b43c1776ba4185b0": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Geoportail France",
+       "max_native_zoom": 18,
+       "max_zoom": 19,
+       "min_native_zoom": 0,
+       "name": "GeoportailFrance.orthos",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://wxs.ign.fr/choisirgeoportail/geoportail/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&STYLE=normal&TILEMATRIXSET=PM&FORMAT=image/jpeg&LAYER=ORTHOIMAGERY.ORTHOPHOTOS&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}"
+      }
+     },
+     "bcad9afb026b4e3288544c6f223ddb48": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_96402a9bdaf34956a2a5b811c50a554b",
+       "style": "IPY_MODEL_66d891bfc24844c386cddcdd246a88cb",
+       "value": "Location:(-75.74062510133014,36.10613398011216)"
+      }
+     },
+     "bcb6b50367a8450e814ea742d383cc88": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.10600655807756,
+        -75.71356462034225
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_b6b1d754e7624100af6de767aaa669b9",
+       "title": "Location:(-75.71356462034225,36.10600655807756)"
+      }
+     },
+     "bd16c7805d0a479f831ce526a80ad694": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "bd3caaa184704bc7961a3c7ec30c204e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "bdb676e286b54c058d4491de34f9b0c8": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletWMSLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "MRLC",
+       "crs": {
+        "custom": false,
+        "name": "EPSG3857"
+       },
+       "format": "image/png",
+       "layers": "NLCD_2001_Land_Cover_L48",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "NLCD 2001 CONUS Land Cover",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "format",
+        "layers",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "styles",
+        "tile_size",
+        "tms",
+        "transparent",
+        "uppercase"
+       ],
+       "transparent": true,
+       "url": "https://www.mrlc.gov/geoserver/mrlc_display/NLCD_2001_Land_Cover_L48/wms?"
+      }
+     },
+     "be111ab9df634df59477eda394b7303d": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Datenquelle: basemap.at",
+       "max_native_zoom": 18,
+       "max_zoom": 19,
+       "min_native_zoom": 0,
+       "name": "BasemapAT.terrain",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://maps.wien.gv.at/basemap/bmapgelaende/grau/google3857/{z}/{y}/{x}.jpeg"
+      }
+     },
+     "bea1419f7d724badb37c5c5decef7d0c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "bea897431f5d405abe6afc9c81736393": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "bf63f1021a2348d59f33e81c0fb29ba8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "bf682e14ae4c4b55a0a88d60982d730b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "bfa5c14870ce4210a1a559c10bc5cd32": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_09c22a2918bc47e7934672c33e89561c",
+       "style": "IPY_MODEL_313d8c1b48804032ba2a1ad0fa1c3e47",
+       "value": "Location:(-75.74546582382159,36.09979789465861)"
+      }
+     },
+     "c01eb5edfb4a47659c9fcd21062d09a7": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c0edac7f69f54535b9cac784d0cc46e6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c10117c786e841e6aa111e9a944095b9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c129aed9587147eba67f52d8e0f4657d": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.12549030644811,
+        -75.74840459138716
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_5abb8e79df824849bb50fdac84ee2825",
+       "title": "Location:(-75.74840459138716,36.12549030644811)"
+      }
+     },
+     "c135f5bb89874afe95066053f480318d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "height": "auto",
+       "padding": "0px 0px 0px 4px",
+       "width": "auto"
+      }
+     },
+     "c16ab02f58d5445a83f75fd6ca474bbc": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "![](https://docs.onemap.sg/maps/images/oneMap64-01.png) New OneMap | Map data (C) contributors, Singapore Land Authority",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "OneMapSG.Default",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://maps-a.onemap.sg/v3/Default/{z}/{x}/{y}.png"
+      }
+     },
+     "c16d8fdf8b3244b289d3c8c233d126a2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c25de9e1e9104836972cb9e5294cefbd": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c3052fbc9a824efeb03ba6532589276c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_288cb5febefb42ee9674ac71ddd42c78",
+       "style": "IPY_MODEL_52cd2aac867d4c41a0bfb67cbd913e65",
+       "value": "Location:(-75.74481957704504,36.09804379626511)"
+      }
+     },
+     "c3160fb37fcf45a0a7770d54b5db7988": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c3b4ab25909342f2a4f7959578071d40": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c4b73fb5240f46fa92387b14bece0aa6": {
+      "model_module": "@here/map-widget-for-jupyter",
+      "model_module_version": "^1.1.3",
+      "model_name": "DefaultLayersModel",
+      "state": {
+       "_model_module": "@here/map-widget-for-jupyter",
+       "_model_module_version": "^1.1.3",
+       "_view_count": null,
+       "_view_module": "@here/map-widget-for-jupyter",
+       "_view_module_version": "^1.1.3",
+       "layer_name": "raster.terrain.xbase",
+       "ppi": null
+      }
+     },
+     "c5e90edf7caa4fc58ef91f211a477a16": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c601f121e3324187a00d13253e1128a0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c65138f42e4b4ecbb3e514765f66a69b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_ec3f06bf9cde4902b15e730233570231",
+       "style": "IPY_MODEL_c6e65df720da46efa0eb1fa35fc6013c",
+       "value": "Location:(-75.75181752641937,36.12301212526756)"
+      }
+     },
+     "c65484c8b8bf4eb5a53ffd349615296d": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map tiles by <a href=\"https://labs.strava.com/heatmap\">Strava 2021</a>",
+       "max_native_zoom": 18,
+       "max_zoom": 15,
+       "min_native_zoom": 0,
+       "name": "Strava.All",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://heatmap-external-a.strava.com/tiles/all/hot/{z}/{x}/{y}.png"
+      }
+     },
+     "c6e65df720da46efa0eb1fa35fc6013c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "c71ad173c7d948e5818ba215cacf9b40": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_dd1142b42ade4ad5aed917678eeffa05",
+       "style": "IPY_MODEL_efcf759b506f4674bc2e94f590967ede",
+       "value": "Location:(-75.74325062866691,36.119983148429974)"
+      }
+     },
+     "c72dc77297a54d8ca6134e34ba4db112": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ToggleButtonModel",
+      "state": {
+       "button_style": "primary",
+       "icon": "gears",
+       "layout": "IPY_MODEL_93f734884768437abdb66c8bfd73bc59",
+       "style": "IPY_MODEL_5c99b50058db40a7a12fa17cac0e4790",
+       "tooltip": "WhiteboxTools for local geoprocessing"
+      }
+     },
+     "c74d3773a21e45a5b10a63d174174e43": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.10951545863337,
+        -75.71552137788503
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_ebb2ed411565430ab7589b30a4c1d11f",
+       "title": "Location:(-75.71552137788503,36.10951545863337)"
+      }
+     },
+     "c8605ec4ff6c4a13bf8b7b1434d16a19": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "(C) OpenStreetMap contributors (C) CARTO",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "CartoDB.DarkMatterNoLabels",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://a.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}.png"
+      }
+     },
+     "c8c9d962d7e7400ab81579a6edc8ad33": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletWMSLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "MRLC",
+       "crs": {
+        "custom": false,
+        "name": "EPSG3857"
+       },
+       "format": "image/png",
+       "layers": "NLCD_2011_Land_Cover_L48",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "NLCD 2011 CONUS Land Cover",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "format",
+        "layers",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "styles",
+        "tile_size",
+        "tms",
+        "transparent",
+        "uppercase"
+       ],
+       "transparent": true,
+       "url": "https://www.mrlc.gov/geoserver/mrlc_display/NLCD_2011_Land_Cover_L48/wms?"
+      }
+     },
+     "c8e5c5c2e96243d0a081ad618d3b9bfc": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "(C) OpenStreetMap contributors (C) CARTO",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "CartoDB.DarkMatterOnlyLabels",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://a.basemaps.cartocdn.com/dark_only_labels/{z}/{x}/{y}.png"
+      }
+     },
+     "c9373c3e55af48ffbd5d6a608f0fd39a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c97c86b7270d4645b969025b3e0fcf65": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "c99a854d8c594ea2a7acc27bc08e26cc": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Kaartgegevens (C) Kadaster",
+       "max_native_zoom": 18,
+       "max_zoom": 19,
+       "min_native_zoom": 0,
+       "name": "nlmaps.water",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/water/EPSG:3857/{z}/{x}/{y}.png"
+      }
+     },
+     "caffcea9f39243919ac7559acbcd0308": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "cb277df1b8454adcb6617b4b07e39199": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletGeoJSONModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "data": {
+        "features": [
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.749595,
+              36.113358
+             ],
+             [
+              -75.749595,
+              36.115358
+             ],
+             [
+              -75.747595,
+              36.115358
+             ],
+             [
+              -75.747595,
+              36.113358
+             ],
+             [
+              -75.749595,
+              36.113358
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 53,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746894,
+              36.115993
+             ],
+             [
+              -75.746894,
+              36.117993
+             ],
+             [
+              -75.744894,
+              36.117993
+             ],
+             [
+              -75.744894,
+              36.115993
+             ],
+             [
+              -75.746894,
+              36.115993
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 89,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746624,
+              36.114914
+             ],
+             [
+              -75.746624,
+              36.116914
+             ],
+             [
+              -75.744624,
+              36.116914
+             ],
+             [
+              -75.744624,
+              36.114914
+             ],
+             [
+              -75.746624,
+              36.114914
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 90,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746354,
+              36.113834
+             ],
+             [
+              -75.746354,
+              36.115834
+             ],
+             [
+              -75.744354,
+              36.115834
+             ],
+             [
+              -75.744354,
+              36.113834
+             ],
+             [
+              -75.746354,
+              36.113834
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 91,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         }
+        ],
+        "type": "FeatureCollection"
+       },
+       "hover_style": {
+        "fillColor": "blue"
+       },
+       "name": "Selected ROIs"
+      }
+     },
+     "cb4c0ea516184f98999a2eabeef3d470": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "cc40b5f17dea499c880bdef27ef2a2a3": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_87de96ac86a04a9fb1e66aa4af0306df",
+       "style": "IPY_MODEL_cf16d3555eb544b3a08808875cff6860",
+       "value": "Location:(-75.71997919999295,36.11734249665222)"
+      }
+     },
+     "cc5aad92689443d1bec5eb6dd38e1a87": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map tiles by Stamen Design, CC BY 3.0 -- Map data (C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "Stamen.Terrain",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://stamen-tiles-a.a.ssl.fastly.net/terrain/{z}/{x}/{y}.png"
+      }
+     },
+     "cc62bfc510de4224887019b1eefc009e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_c10117c786e841e6aa111e9a944095b9",
+       "style": "IPY_MODEL_165f79c2c0d24993856bb56b9036203f",
+       "value": "Location:(-75.74859464130445,36.11435777933147)"
+      }
+     },
+     "cc9ab222aa7741e0a4857e24715b9281": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "cca24d41ce8641d392b450d4567a54e8": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.09535859916541,
+        -75.70794371391897
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_8981008afd2e407ba361719563b3fbea",
+       "title": "Location:(-75.70794371391897,36.09535859916541)"
+      }
+     },
+     "cca4015673514a1f856fbf172d1de565": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ccb584ba418243b0a3a9e9bdd608032a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ccf75176a61540dda285b9c29337b8de": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5c3531fd074c491cb9a957aeb4f53824",
+       "style": "IPY_MODEL_5d70d81bbbee428d97de6ff5f11a0146",
+       "value": "Location:(-75.7105871267463,36.10076002831213)"
+      }
+     },
+     "cd302987ed464778ba65d4ab32ebd9b5": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Tiles (C) Esri -- Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, FAO, NPS, NRCAN, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community",
+       "max_native_zoom": 18,
+       "max_zoom": 22,
+       "min_native_zoom": 0,
+       "name": "Esri.WorldTopoMap",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}"
+      }
+     },
+     "cd3db9533f2d42c684cee3ac9c116a66": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletAttributionControlModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "options": [
+        "position",
+        "prefix"
+       ],
+       "position": "bottomright",
+       "prefix": "ipyleaflet"
+      }
+     },
+     "cd5afda18eba4828a1e87a309588389b": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "(C) OpenStreetMap contributors (C) CARTO",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "CartoDB.DarkMatter",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png"
+      }
+     },
+     "cd5cff2badfa4e79968fbfb375a6f158": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map tiles by Stamen Design, CC BY 3.0 -- Map data (C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "Stamen.Toner",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://stamen-tiles-a.a.ssl.fastly.net/toner/{z}/{x}/{y}.png"
+      }
+     },
+     "cd67db7900c040a9b2f69c92f90ad46b": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Justice Map",
+       "max_native_zoom": 18,
+       "max_zoom": 22,
+       "min_native_zoom": 0,
+       "name": "JusticeMap.hispanic",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://www.justicemap.org/tile/county/hispanic/{z}/{x}/{y}.png"
+      }
+     },
+     "cde02185e2aa462d90fb5f2afa2be688": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "VBoxModel",
+      "state": {
+       "children": [
+        "IPY_MODEL_6b5b57db251247f98fee9a8943ee4d36"
+       ],
+       "layout": "IPY_MODEL_fec74fe8ff3b4bba944bf1f7ab2c091d"
+      }
+     },
+     "ce0af72f44dc4d339a9494c1d0b6b53f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "ce3ee280e8eb4c579ab573f90cc78b3e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_f0140cd2d84347ba83e7735293c6181e",
+       "style": "IPY_MODEL_7c129cc8eaa84a42a7eebf528cfa6248",
+       "value": "Location:(-75.71307486020319,36.105128378365755)"
+      }
+     },
+     "ce506d02f07d49238a6a720a4161291c": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerClusterModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "disable_clustering_at_zoom": 18,
+       "markers": [
+        "IPY_MODEL_ec930c8c9e454287a054074798f10b26",
+        "IPY_MODEL_2c018069ee0f453081d896c19637959c",
+        "IPY_MODEL_df3adb091ef04744add526cec2978fa2",
+        "IPY_MODEL_26f0281152ac4a0b877e781e5cbc8323",
+        "IPY_MODEL_984e44404e6449bda1f87d867ac912eb",
+        "IPY_MODEL_4be5b3861f314895839a01de4feb3524",
+        "IPY_MODEL_81c6a9b3ca0e4e069607b56630e7faec",
+        "IPY_MODEL_8df4a45ca59a4313b88a4deac113a7ee",
+        "IPY_MODEL_833407eb9acf4c0688de3993e5026210",
+        "IPY_MODEL_a1104be85f7a4b47a056a68f3071fb03",
+        "IPY_MODEL_7c944b5948254660866866441903ef7c",
+        "IPY_MODEL_1aa3b693c6ce43bdb526089a9eb25519",
+        "IPY_MODEL_e8c8d56f3c984330bccd4844ed110f73",
+        "IPY_MODEL_7d9a972ce0fa473c834833c5e6371c2f",
+        "IPY_MODEL_47563edcf6074a62942146c10fcfd219",
+        "IPY_MODEL_f4384908e57549579be1c28c9e94eab7",
+        "IPY_MODEL_083b72344af3429ea796fefbd13ac9a5",
+        "IPY_MODEL_a75f4aee335f4e458a3c879e997daa1c",
+        "IPY_MODEL_f17b31a5c75e4d5aad82bafbd95208c2",
+        "IPY_MODEL_c74d3773a21e45a5b10a63d174174e43",
+        "IPY_MODEL_1c799939e50447b0a3a42540d4365d89",
+        "IPY_MODEL_87a205e6fb874058a9346819876cc881",
+        "IPY_MODEL_166c030555e74895a6b4678bda24f2eb",
+        "IPY_MODEL_bcb6b50367a8450e814ea742d383cc88",
+        "IPY_MODEL_5acd693af1704d8ead28c4e83fffa86e",
+        "IPY_MODEL_348ac71e68864a9494a5fe886d676080",
+        "IPY_MODEL_e044b158034c4a2cbdced568f5b80a6b",
+        "IPY_MODEL_fd9b1599821a4314b01d741a33e579b3",
+        "IPY_MODEL_ed4bbd2a2d564f4bb840e9f878164146",
+        "IPY_MODEL_ceea10513ded49969e939f9b207fe120",
+        "IPY_MODEL_6d74f8f207a945838c712059d6eaaba2",
+        "IPY_MODEL_4f42466288214b0da8aaa739819c9524",
+        "IPY_MODEL_bb8ea54d89fa48bdb1890a4de5df311d",
+        "IPY_MODEL_08d1aa4b59164dd49baf15d821c2a983",
+        "IPY_MODEL_301f0a63c0b04cd48f80712d1617f471",
+        "IPY_MODEL_cca24d41ce8641d392b450d4567a54e8",
+        "IPY_MODEL_aefefb887adc4542ac813a1258d06381",
+        "IPY_MODEL_b22c6b54d17f47378e36a90978505bce",
+        "IPY_MODEL_446068f836a547a3b62f01a269c4287c",
+        "IPY_MODEL_11c063779af44a5b83c26f09822b246a",
+        "IPY_MODEL_fd0f883b0b2b431da058386d0156aadd",
+        "IPY_MODEL_cfcc1db948104dc08597ce2d31b90adf",
+        "IPY_MODEL_3cf000e3e98c461c9eaad1888be26702",
+        "IPY_MODEL_46b348d21c7a4c1ebb5b89a90f3f38d4",
+        "IPY_MODEL_5b4240a5c1a2499cb98bf626d164b3bf",
+        "IPY_MODEL_f711a4e504004927bc6837cfc4e67459",
+        "IPY_MODEL_4f4509f603d245eea527b5d03f0d02da",
+        "IPY_MODEL_b15ae74c7b5649ae8df4c32847b9a277",
+        "IPY_MODEL_8ae05c6a6ebb405bbd5cfc47df9edf07",
+        "IPY_MODEL_d7cfda901ef24ec4b307601e3acd5bef",
+        "IPY_MODEL_e24a93daf1b34c1893743ef51a891f57",
+        "IPY_MODEL_736e67af1f6a48faabf5898d0abb5bed",
+        "IPY_MODEL_e505cd9b361346fa84f498d5c825192c",
+        "IPY_MODEL_94b6d2eb9386446499e13ea6c5d75576",
+        "IPY_MODEL_1dbaa2f0a9ea4f91b8c46afb7c9b6286",
+        "IPY_MODEL_1c8a94cd6f98458782f4f7bce9f8e99a",
+        "IPY_MODEL_42c0f81fa0c34f008acaa0339c29a5cc",
+        "IPY_MODEL_670e1b367cef4e69905f1f89dfb08261",
+        "IPY_MODEL_909a098203ef406ca67c5a8921b16e1d",
+        "IPY_MODEL_2ccb8ab9a42f4150b75505346faca378",
+        "IPY_MODEL_36d7cf872d5e4c99a39751e65586362c",
+        "IPY_MODEL_01bbf70de21f49bda35f0eca3f62ce35",
+        "IPY_MODEL_06a8c24376204a6a910b8addf81a05ec",
+        "IPY_MODEL_e9e5bc6dc158457aa45684952dd9ce86",
+        "IPY_MODEL_617cd9de2c754d5fa7530fa82b449608",
+        "IPY_MODEL_b980bda5427442d7a494956f9e1026a4",
+        "IPY_MODEL_f75e84c299f0454c834c4b69bc569765",
+        "IPY_MODEL_76bdcb7c39414b6e86e0912ab02a0a38",
+        "IPY_MODEL_4302d664c8334817a20a9aaedd3c6735",
+        "IPY_MODEL_9ff8dcb052b249e1893b3c334df72bd4",
+        "IPY_MODEL_357ca585d5424e5e8579c9f77ec5e42d",
+        "IPY_MODEL_4651104c0d9e42ddac9a1b2966d1aee2",
+        "IPY_MODEL_49e0d7044adc4d759f646e007aadaa91",
+        "IPY_MODEL_091e75f9eb734ceaa3735ae7939d6ab6",
+        "IPY_MODEL_76efc10440bf494383b62d62fecf3bb8",
+        "IPY_MODEL_f3301a2241444a528a7fca09aebbe693",
+        "IPY_MODEL_ef13578828344b20b0e7789cb09b87ce",
+        "IPY_MODEL_3a4c4510750b46d180ed0d8e088b10c4",
+        "IPY_MODEL_2d47e47d2b9c4b14a70c61bc922d218f",
+        "IPY_MODEL_9fc5d0461ebc4429b5b4727793f02859",
+        "IPY_MODEL_915c1c17143b4220858adfee64e91359",
+        "IPY_MODEL_c129aed9587147eba67f52d8e0f4657d",
+        "IPY_MODEL_21bcd7d9375048079bc0682b3b1ff7bb",
+        "IPY_MODEL_56eaa4007081411da57985997a40a381",
+        "IPY_MODEL_a4ce55870dd044ff993ef534e7f77b6b",
+        "IPY_MODEL_d5699ee43cc3474b82f6ee1e30244409",
+        "IPY_MODEL_4bbe30ef6f914b5098059d3643cad23e",
+        "IPY_MODEL_fd0945b2d9b34cf7b4edf0a4b6d24964",
+        "IPY_MODEL_95d123fa142f4ae39d31097dcf5e8515",
+        "IPY_MODEL_70d64ac21ccc4758bbdc405f06ba40cc",
+        "IPY_MODEL_af47addb40c8485b8db8d787ccf787e8",
+        "IPY_MODEL_10bb4bf4025e4cd1b0ad20a17f0b636e",
+        "IPY_MODEL_eda6325a46a54c55b0a1b0d004a85c46",
+        "IPY_MODEL_b0e45a3842d04c41a540458b1f8e09c8",
+        "IPY_MODEL_7a814d0c3ed54f7d84c4e5a21bb60476",
+        "IPY_MODEL_a3c0d9333ada465784228b3dc8608e05",
+        "IPY_MODEL_6a2bedf0367949489265263c7778ab0a",
+        "IPY_MODEL_e61def2a6cb24719a6f50f1c606bdc56",
+        "IPY_MODEL_0df931799d5342fa997ae2aeb25e4d66",
+        "IPY_MODEL_6c3b613d350f4cdb8a1bc66ac9d94a57",
+        "IPY_MODEL_b063155a9c744c2187dcd9febcf80ced",
+        "IPY_MODEL_962436160fe848179a529ef50ee00fcb",
+        "IPY_MODEL_af05e5f52b2e4f6cb075b6cfd356b52d",
+        "IPY_MODEL_3a146af3abb9475294681c683dacc100",
+        "IPY_MODEL_d04530ffd556497da0ca07eed48d4044",
+        "IPY_MODEL_2c5d010dfb6a403da1292cbda4e61d26",
+        "IPY_MODEL_cf63670dc07d4886b6a823bab81f4c6b",
+        "IPY_MODEL_e67c6c143bc1416489e45a88e22f8dd7",
+        "IPY_MODEL_42a65a5036ce41c4b8bd9a52445a874b",
+        "IPY_MODEL_3a019ccf65a14d11a641a838331a5a06",
+        "IPY_MODEL_05f062534a1b4358b105439a0687a7e9",
+        "IPY_MODEL_1baf7ab905d145bcaf61a214cc4c9d60",
+        "IPY_MODEL_1ecc83b5eb114945a58e295efde46064",
+        "IPY_MODEL_699ab69fb4ff4afcb5172e754e81ccf8",
+        "IPY_MODEL_52157ba80d124d4ebb0ef93c10cb3bab",
+        "IPY_MODEL_28b3dfd39c094edbb96f5b02f722864a",
+        "IPY_MODEL_663f43d2ba93488db7f4c99f8b768c1d",
+        "IPY_MODEL_7463293d719a4403a9395cb2bd1b7502",
+        "IPY_MODEL_567ca06b83874297b6cb353a4d2bdd61",
+        "IPY_MODEL_51c9cfbf126d411891a2416f1e837507"
+       ],
+       "max_cluster_radius": 80,
+       "name": "CoastSat Shoreline Data",
+       "options": [
+        "disable_clustering_at_zoom",
+        "max_cluster_radius"
+       ]
+      }
+     },
+     "cea3532ce7fe4547bfdbd3ff7ae62bdd": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_92f1371013a847a19e0ea31e92398f4d",
+       "style": "IPY_MODEL_7e74797415454d629f97eb2e6107e89d",
+       "value": "Location:(-75.71909666828,36.115535407906684)"
+      }
+     },
+     "ceea10513ded49969e939f9b207fe120": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.10076002831213,
+        -75.7105871267463
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_ccf75176a61540dda285b9c29337b8de",
+       "title": "Location:(-75.7105871267463,36.10076002831213)"
+      }
+     },
+     "cf0447a6308b4abba5a0c9344365bb21": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "cf16d3555eb544b3a08808875cff6860": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "cf63670dc07d4886b6a823bab81f4c6b": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.10761944869072,
+        -75.74255057244784
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_d4e0aafaa7864dc9830e448a80a9ff97",
+       "title": "Location:(-75.74255057244784,36.10761944869072)"
+      }
+     },
+     "cf74f99a21fe40ea811cd100f721a1b7": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletWMSLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "MRLC",
+       "crs": {
+        "custom": false,
+        "name": "EPSG3857"
+       },
+       "format": "image/png",
+       "layers": "NLCD_2004_Land_Cover_L48",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "NLCD 2004 CONUS Land Cover",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "format",
+        "layers",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "styles",
+        "tile_size",
+        "tms",
+        "transparent",
+        "uppercase"
+       ],
+       "transparent": true,
+       "url": "https://www.mrlc.gov/geoserver/mrlc_display/NLCD_2004_Land_Cover_L48/wms?"
+      }
+     },
+     "cfcc1db948104dc08597ce2d31b90adf": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.1239457459644,
+        -75.75177306956394
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_94085e32206b49f08f481830507265e8",
+       "title": "Location:(-75.75177306956394,36.1239457459644)"
+      }
+     },
+     "d04530ffd556497da0ca07eed48d4044": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.11891983886272,
+        -75.74292345617727
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_2f858dc8272b414ea5b65033a595cddc",
+       "title": "Location:(-75.74292345617727,36.11891983886272)"
+      }
+     },
+     "d053093e63064c6cab44759d9d4bad72": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_6436314975ab4584913b5b31f35ad54d",
+       "style": "IPY_MODEL_a2f1d1fe96a64e83930053cd4195deed",
+       "value": "Location:(-75.74643343816277,36.11915148265106)"
+      }
+     },
+     "d06b6c12cdc440749ace7f4ee078504a": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map tiles by Stamen Design, CC BY 3.0 -- Map data (C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "Stamen.TonerLabels",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://stamen-tiles-a.a.ssl.fastly.net/toner-labels/{z}/{x}/{y}.png"
+      }
+     },
+     "d09f2f1cb5c94ea08f82283ee67746d1": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d0e47241a1a94ee9b69fca24ef3ad707": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "d174d7a3eb5243758ec19b723ba60c92": {
+      "model_module": "@here/map-widget-for-jupyter",
+      "model_module_version": "^1.1.3",
+      "model_name": "DefaultLayersModel",
+      "state": {
+       "_model_module": "@here/map-widget-for-jupyter",
+       "_model_module_version": "^1.1.3",
+       "_view_count": null,
+       "_view_module": "@here/map-widget-for-jupyter",
+       "_view_module_version": "^1.1.3",
+       "layer_name": "vector.normal.truck",
+       "ppi": null
+      }
+     },
+     "d1af9ed07a234ebdada16cbd1abe1342": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_12b5a6ef1f9144c999ee14501ecd1b0b",
+       "style": "IPY_MODEL_9eeec829c1a140e49bb754702ed4337c",
+       "value": "Location:(-75.74449645365677,36.09716674706836)"
+      }
+     },
+     "d1de76aec63d4be9b5ff6748f329d1ee": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_9e9b0ac2db3e4ec3a002e0be5b9ed1ca",
+       "style": "IPY_MODEL_2dc8fffb1ea34e4e95a27a950ec0ce6c",
+       "value": "Location:(-75.74358848728296,36.12104309057717)"
+      }
+     },
+     "d23d2d5fa81b4e25a39b68d1c35fa0a9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d2534efafc604b52a52f69d50e5d008c": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Datenquelle: basemap.at",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "BasemapAT.basemap",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://maps.wien.gv.at/basemap/geolandbasemap/normal/google3857/{z}/{y}/{x}.png"
+      }
+     },
+     "d3771faeeb254d578ade29ebcdf2128c": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_bd16c7805d0a479f831ce526a80ad694",
+       "style": "IPY_MODEL_bea1419f7d724badb37c5c5decef7d0c",
+       "value": "Location:(-75.71953793413647,36.11643895227945)"
+      }
+     },
+     "d3ea752dd872410aa0b8bd557ae11112": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d47713d2f0d943eda05753da9c04c8e9": {
+      "model_module": "@here/map-widget-for-jupyter",
+      "model_module_version": "^1.1.3",
+      "model_name": "DefaultLayersModel",
+      "state": {
+       "_model_module": "@here/map-widget-for-jupyter",
+       "_model_module_version": "^1.1.3",
+       "_view_count": null,
+       "_view_module": "@here/map-widget-for-jupyter",
+       "_view_module_version": "^1.1.3",
+       "layer_name": "raster.normal.basenight",
+       "ppi": null
+      }
+     },
+     "d478272040ff470197405dce4c7dfc6a": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Tiles courtesy of the U.S. Geological Survey",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "USGS.USTopo",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://basemap.nationalmap.gov/arcgis/rest/services/USGSTopo/MapServer/tile/{z}/{y}/{x}"
+      }
+     },
+     "d4e0aafaa7864dc9830e448a80a9ff97": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_207b3977ec684ff4bbb5d5f4af217032",
+       "style": "IPY_MODEL_4e7273ff3a9342119f9f30c179375e13",
+       "value": "Location:(-75.74255057244784,36.10761944869072)"
+      }
+     },
+     "d53df8ff9536443da0a1042077500e02": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d5699ee43cc3474b82f6ee1e30244409": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.12131006089669,
+        -75.74697308272417
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_69ba212b3a184ed69e592826e379c566",
+       "title": "Location:(-75.74697308272417,36.12131006089669)"
+      }
+     },
+     "d5b67a6bbb61415b942a13aad40e107f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "d5f2e477b83a4191843bf5d8d915538a": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d630687dff634a8e9b79296d49793f20": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "d6d8b599ca4a44279cf5f847ce37447e": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_3fb1b3244b8346e4bde7f19a98084235",
+       "style": "IPY_MODEL_bf63f1021a2348d59f33e81c0fb29ba8",
+       "value": "Location:(-75.74903784076923,36.126405)"
+      }
+     },
+     "d70114babc9c4dd18e1a5d2646ed67d0": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletGeoJSONModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "data": {
+        "features": [
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.750342,
+              36.11606
+             ],
+             [
+              -75.750342,
+              36.11806
+             ],
+             [
+              -75.748342,
+              36.11806
+             ],
+             [
+              -75.748342,
+              36.11606
+             ],
+             [
+              -75.750342,
+              36.11606
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 50,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.749844,
+              36.114259
+             ],
+             [
+              -75.749844,
+              36.116259
+             ],
+             [
+              -75.747844,
+              36.116259
+             ],
+             [
+              -75.747844,
+              36.114259
+             ],
+             [
+              -75.749844,
+              36.114259
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 52,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.749595,
+              36.113358
+             ],
+             [
+              -75.749595,
+              36.115358
+             ],
+             [
+              -75.747595,
+              36.115358
+             ],
+             [
+              -75.747595,
+              36.113358
+             ],
+             [
+              -75.749595,
+              36.113358
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 53,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746894,
+              36.115993
+             ],
+             [
+              -75.746894,
+              36.117993
+             ],
+             [
+              -75.744894,
+              36.117993
+             ],
+             [
+              -75.744894,
+              36.115993
+             ],
+             [
+              -75.746894,
+              36.115993
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 89,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746624,
+              36.114914
+             ],
+             [
+              -75.746624,
+              36.116914
+             ],
+             [
+              -75.744624,
+              36.116914
+             ],
+             [
+              -75.744624,
+              36.114914
+             ],
+             [
+              -75.746624,
+              36.114914
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 90,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746354,
+              36.113834
+             ],
+             [
+              -75.746354,
+              36.115834
+             ],
+             [
+              -75.744354,
+              36.115834
+             ],
+             [
+              -75.744354,
+              36.113834
+             ],
+             [
+              -75.746354,
+              36.113834
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 91,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         }
+        ],
+        "type": "FeatureCollection"
+       },
+       "hover_style": {
+        "fillColor": "blue"
+       },
+       "name": "Selected ROIs"
+      }
+     },
+     "d724da2ff96c4256b154f07961655e98": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_eb26976573f84e1eb781e07426995939",
+       "style": "IPY_MODEL_c3b4ab25909342f2a4f7959578071d40",
+       "value": "Location:(-75.74934215811618,36.11706034011234)"
+      }
+     },
+     "d7cfda901ef24ec4b307601e3acd5bef": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.117957968781134,
+        -75.74960191292703
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_3068b017f61249dc841851fe905d1a28",
+       "title": "Location:(-75.74960191292703,36.117957968781134)"
+      }
+     },
+     "d800152693454dd0a229b979555ff511": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "d93dff5f701e41fea21e70ab3edb4ca8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_570d978d891d4467adef2280b0e2246a",
+       "style": "IPY_MODEL_2bf0830bf900484887137bee92c955b3",
+       "value": "Location:(-75.74310252769837,36.10855981309512)"
+      }
+     },
+     "d95db1fbe3a1493b9cf7193649b30722": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletWMSLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "MRLC",
+       "crs": {
+        "custom": false,
+        "name": "EPSG3857"
+       },
+       "format": "image/png",
+       "layers": "NLCD_2013_Land_Cover_L48",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "NLCD 2013 CONUS Land Cover",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "format",
+        "layers",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "styles",
+        "tile_size",
+        "tms",
+        "transparent",
+        "uppercase"
+       ],
+       "transparent": true,
+       "url": "https://www.mrlc.gov/geoserver/mrlc_display/NLCD_2013_Land_Cover_L48/wms?"
+      }
+     },
+     "d96726e9ea2f4803939dfc03e9bd58c4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_7023d1ae47f64c0d8677c1aa6d481e76",
+       "style": "IPY_MODEL_55367ff771c84f8cb4ee4df417cdcc28",
+       "value": "Location:(-75.71710320460038,36.11206192026365)"
+      }
+     },
+     "da0baa34ca80408e80397f3111bc6fd5": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "da3e4a0975634822ab74b8280fa8864f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_94d376863ca849df81efcc637682821a",
+       "style": "IPY_MODEL_7bd1bed1e5af40c3bc0556dc61cc9eb8",
+       "value": "Location:(-75.72339254288157,36.124626448803426)"
+      }
+     },
+     "da5626455eef43f4bc011eb0a9e4892d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "dafd8ac0f19c4c2a979b8aebfc126ace": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "dbbb915196d7405aabdbd12a10a0d761": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Google",
+       "max_native_zoom": 18,
+       "max_zoom": 22,
+       "min_native_zoom": 0,
+       "name": "Google Satellite",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://mt1.google.com/vt/lyrs=y&x={x}&y={y}&z={z}"
+      }
+     },
+     "dc68d2a27a6a48b6bcd801ef1b0bb101": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_ebd4d24fd9104aaaaef305f7acf3e1f9",
+       "style": "IPY_MODEL_49d0daeeb21d4d659958d69ba61dbd76",
+       "value": "Location:(-75.74724290500487,36.1223893500195)"
+      }
+     },
+     "dc68e112a2e04be39d17608c12ee9b78": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Datenquelle: basemap.at",
+       "max_native_zoom": 18,
+       "max_zoom": 19,
+       "min_native_zoom": 0,
+       "name": "BasemapAT.grau",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://maps.wien.gv.at/basemap/bmapgrau/normal/google3857/{z}/{y}/{x}.png"
+      }
+     },
+     "dcaf1b1f150e4c96ae8aa04151ef5aa9": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "dcc9f9f481c84a31acc5759283046d11": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "dcca9401313f45b696f4454d44904218": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletWMSLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "FWS",
+       "crs": {
+        "custom": false,
+        "name": "EPSG3857"
+       },
+       "format": "image/png",
+       "layers": "0",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "FWS NWI Wetlands Raster",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "format",
+        "layers",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "styles",
+        "tile_size",
+        "tms",
+        "transparent",
+        "uppercase"
+       ],
+       "transparent": true,
+       "url": "https://www.fws.gov/wetlands/arcgis/services/Wetlands_Raster/ImageServer/WMSServer?"
+      }
+     },
+     "dcf57f7a135745279586a1fb16185143": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "ToggleButtonModel",
+      "state": {
+       "button_style": "primary",
+       "icon": "download",
+       "layout": "IPY_MODEL_8f02b740ad3c47a09341ce16b3ec1ff2",
+       "style": "IPY_MODEL_ab4328cd37694dcbb22fc623ca7ec74e",
+       "tooltip": "Download OSM data"
+      }
+     },
+     "dd1142b42ade4ad5aed917678eeffa05": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "dd55eacb5a7443f0bbdc04dcfb965f56": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Tiles courtesy of OpenStreetMap Sweden -- Map data (C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "Hydda.Base",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://a.tile.openstreetmap.se/hydda/base/{z}/{x}/{y}.png"
+      }
+     },
+     "de1b1e47e5eb42f18fcfeba68e246986": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "height": "auto",
+       "padding": "0px 0px 0px 4px",
+       "width": "auto"
+      }
+     },
+     "defbd341473942f298aef507213be753": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletGeoJSONModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "data": {
+        "features": [
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746894,
+              36.115993
+             ],
+             [
+              -75.746894,
+              36.117993
+             ],
+             [
+              -75.744894,
+              36.117993
+             ],
+             [
+              -75.744894,
+              36.115993
+             ],
+             [
+              -75.746894,
+              36.115993
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 89,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746624,
+              36.114914
+             ],
+             [
+              -75.746624,
+              36.116914
+             ],
+             [
+              -75.744624,
+              36.116914
+             ],
+             [
+              -75.744624,
+              36.114914
+             ],
+             [
+              -75.746624,
+              36.114914
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 90,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746354,
+              36.113834
+             ],
+             [
+              -75.746354,
+              36.115834
+             ],
+             [
+              -75.744354,
+              36.115834
+             ],
+             [
+              -75.744354,
+              36.113834
+             ],
+             [
+              -75.746354,
+              36.113834
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 91,
+           "style": {
+            "color": "blue",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 2
+           }
+          },
+          "type": "Feature"
+         }
+        ],
+        "type": "FeatureCollection"
+       },
+       "hover_style": {
+        "fillColor": "blue"
+       },
+       "name": "Selected ROIs"
+      }
+     },
+     "df14ca0bc797476286e4e423abff782b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "df3adb091ef04744add526cec2978fa2": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.124626448803426,
+        -75.72339254288157
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_da3e4a0975634822ab74b8280fa8864f",
+       "title": "Location:(-75.72339254288157,36.124626448803426)"
+      }
+     },
+     "dfdc3ffba8bb4097b96a1bb7aa6592e4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e044b158034c4a2cbdced568f5b80a6b": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.10337186400442,
+        -75.71209553504248
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_40e1230ba6a84379ab8b489e50c77d7a",
+       "title": "Location:(-75.71209553504248,36.10337186400442)"
+      }
+     },
+     "e051e3f81cd148a8a250b4f96de61c1a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_c9373c3e55af48ffbd5d6a608f0fd39a",
+       "style": "IPY_MODEL_a66730019d2a4b70ae9b7857e52575a9",
+       "value": "Location:(-75.7096722969865,36.098976094110064)"
+      }
+     },
+     "e0a353cd33a34f7f8368f6cdd49720b8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e0bc984ba36847e582a35017c8d0e8fc": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e1b9681ed391467198bc9eff25bb0f64": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "(C) OpenStreetMap contributors (C) CARTO",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "CartoDB.VoyagerLabelsUnder",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://a.basemaps.cartocdn.com/rastertiles/voyager_labels_under/{z}/{x}/{y}.png"
+      }
+     },
+     "e1f31d76b20f4b1eb9a8d17226435434": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Justice Map",
+       "max_native_zoom": 18,
+       "max_zoom": 22,
+       "min_native_zoom": 0,
+       "name": "JusticeMap.asian",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://www.justicemap.org/tile/county/asian/{z}/{x}/{y}.png"
+      }
+     },
+     "e243f9e61e064aea9e872d467ef67eed": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "e24a93daf1b34c1893743ef51a891f57": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.11706034011234,
+        -75.74934215811618
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_d724da2ff96c4256b154f07961655e98",
+       "title": "Location:(-75.74934215811618,36.11706034011234)"
+      }
+     },
+     "e292c64df2cb48589b52b5bfde80976b": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_798acf5f0ef0404a85d1bdbefa9094ec",
+       "style": "IPY_MODEL_83e92842567e43d9b5d838e3417a36e7",
+       "value": "Location:(-75.75114017583925,36.12563157613164)"
+      }
+     },
+     "e295c228529a42e287be9f4e2e331e70": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_7eee3efc599d4a5d853794b5e129dfc2",
+       "style": "IPY_MODEL_f5a74e94d95c4b79825f2eacddebbc75",
+       "value": "Location:(-75.74008971390425,36.10940631770024)"
+      }
+     },
+     "e38409848e7a45aa8d71c58f9e0287f8": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_77bbcc92290c48cda0ac012e8da26fd7",
+       "style": "IPY_MODEL_dcc9f9f481c84a31acc5759283046d11",
+       "value": "Location:(-75.74589379360137,36.116992904405436)"
+      }
+     },
+     "e505cd9b361346fa84f498d5c825192c": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.11525863292509,
+        -75.74884381357502
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_eeb6acbed66a4f9fb1198434eaa5eee4",
+       "title": "Location:(-75.74884381357502,36.11525863292509)"
+      }
+     },
+     "e5466133177e4c71ab5cf9eb6c217bc0": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e567c9c89e234202a79078fe99780c62": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map tiles by Stamen Design, CC BY 3.0 -- Map data (C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "Stamen.TerrainLabels",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://stamen-tiles-a.a.ssl.fastly.net/terrain-labels/{z}/{x}/{y}.png"
+      }
+     },
+     "e5f690c0047e4226ac48c23bc5f2ead5": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e61def2a6cb24719a6f50f1c606bdc56": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.12210187189958,
+        -75.74393002964503
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_82991695a3d546429fa58dbb7c8f8187",
+       "title": "Location:(-75.74393002964503,36.12210187189958)"
+      }
+     },
+     "e67c6c143bc1416489e45a88e22f8dd7": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.11675779210832,
+        -75.74244470740999
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_7dd53463a34d4332a6328246c594c803",
+       "title": "Location:(-75.74244470740999,36.11675779210832)"
+      }
+     },
+     "e84fcdc7593f4f90b1970c51f959b524": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_8c644bfb1a874698924f1fec3eb8bc82",
+       "style": "IPY_MODEL_2020cc59927e4fa39f12a9fffb5accad",
+       "value": "Location:(-75.74808415553382,36.112559590252594)"
+      }
+     },
+     "e87611b36d814edda5326455f65e8f0d": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_a7caadf1f3c74195b62eac7b22fca61a",
+       "style": "IPY_MODEL_5ff70459c2484d2ab468965c40c48b93",
+       "value": "Location:(-75.7408556854917,36.111495327949704)"
+      }
+     },
+     "e8c8d56f3c984330bccd4844ed110f73": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.115535407906684,
+        -75.71909666828
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_cea3532ce7fe4547bfdbd3ff7ae62bdd",
+       "title": "Location:(-75.71909666828,36.115535407906684)"
+      }
+     },
+     "e9183320b964479abbe6d54ed1357157": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "e91e50ba5dbe478bb9bfddeaa4b50894": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5d8d0c8edf2d4d59924dd723ada42fdc",
+       "style": "IPY_MODEL_f14118e294c541ccb6eb648b4c92e632",
+       "value": "Location:(-75.70890657969125,36.09711649496446)"
+      }
+     },
+     "e9a775c5689145a28d7269942a76c4dc": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "(C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "max_zoom": 19,
+       "min_native_zoom": 0,
+       "name": "OpenStreetMap.Mapnik",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      }
+     },
+     "e9e5bc6dc158457aa45684952dd9ce86": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.10533204096554,
+        -75.74620989409237
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_bb81c333e48649ba93749ae50f67c589",
+       "title": "Location:(-75.74620989409237,36.10533204096554)"
+      }
+     },
+     "e9f91e60d3644d98bd5d12f6c44e8a2a": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletWMSLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "USGS",
+       "crs": {
+        "custom": false,
+        "name": "EPSG3857"
+       },
+       "format": "image/png",
+       "layers": "0",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "USGS NAIP Imagery",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "format",
+        "layers",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "styles",
+        "tile_size",
+        "tms",
+        "transparent",
+        "uppercase"
+       ],
+       "transparent": true,
+       "url": "https://services.nationalmap.gov/arcgis/services/USGSNAIPImagery/ImageServer/WMSServer?"
+      }
+     },
+     "ea0c505d52924bde9ed263611dcf0094": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_37f64fe6b5eb4d97b73a00af8dfb4373",
+       "style": "IPY_MODEL_52cd5d468d3e48ccb14809911d0dcb83",
+       "value": "Location:(-75.71006278860439,36.09990202044353)"
+      }
+     },
+     "ea585fbc5d7549b8863bebec65d7425a": {
+      "model_module": "@here/map-widget-for-jupyter",
+      "model_module_version": "^1.1.3",
+      "model_name": "DefaultLayersModel",
+      "state": {
+       "_model_module": "@here/map-widget-for-jupyter",
+       "_model_module_version": "^1.1.3",
+       "_view_count": null,
+       "_view_module": "@here/map-widget-for-jupyter",
+       "_view_module_version": "^1.1.3",
+       "layer_name": "raster.normal.labels",
+       "ppi": null
+      }
+     },
+     "eae2bfca1c6e4d76b0ad2ede30068dc2": {
+      "model_module": "@here/map-widget-for-jupyter",
+      "model_module_version": "^1.1.3",
+      "model_name": "DefaultLayersModel",
+      "state": {
+       "_model_module": "@here/map-widget-for-jupyter",
+       "_model_module_version": "^1.1.3",
+       "_view_count": null,
+       "_view_module": "@here/map-widget-for-jupyter",
+       "_view_module_version": "^1.1.3",
+       "layer_name": "raster.satellite.map",
+       "ppi": null
+      }
+     },
+     "eb058bb3e161466c8936597498c8b2da": {
+      "model_module": "@here/map-widget-for-jupyter",
+      "model_module_version": "^1.1.3",
+      "model_name": "DefaultLayersModel",
+      "state": {
+       "_model_module": "@here/map-widget-for-jupyter",
+       "_model_module_version": "^1.1.3",
+       "_view_count": null,
+       "_view_module": "@here/map-widget-for-jupyter",
+       "_view_module_version": "^1.1.3",
+       "layer_name": "raster.normal.transit",
+       "ppi": null
+      }
+     },
+     "eb26976573f84e1eb781e07426995939": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "eb776508f6e54cad8d4c6470f3031f87": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "eb7bd4e637ae403eaa67f99af3ad6dbc": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletGeoJSONModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "data": {
+        "features": [
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.725329,
+              36.125405
+             ],
+             [
+              -75.725329,
+              36.127405
+             ],
+             [
+              -75.723329,
+              36.127405
+             ],
+             [
+              -75.723329,
+              36.125405
+             ],
+             [
+              -75.725329,
+              36.125405
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 0,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.72484,
+              36.124526
+             ],
+             [
+              -75.72484,
+              36.126526
+             ],
+             [
+              -75.72284,
+              36.126526
+             ],
+             [
+              -75.72284,
+              36.124526
+             ],
+             [
+              -75.72484,
+              36.124526
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 1,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.724393,
+              36.123626
+             ],
+             [
+              -75.724393,
+              36.125626
+             ],
+             [
+              -75.722393,
+              36.125626
+             ],
+             [
+              -75.722393,
+              36.123626
+             ],
+             [
+              -75.724393,
+              36.123626
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 2,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.723974,
+              36.122712
+             ],
+             [
+              -75.723974,
+              36.124712
+             ],
+             [
+              -75.721974,
+              36.124712
+             ],
+             [
+              -75.721974,
+              36.122712
+             ],
+             [
+              -75.723974,
+              36.122712
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 3,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.723556,
+              36.121797
+             ],
+             [
+              -75.723556,
+              36.123797
+             ],
+             [
+              -75.721556,
+              36.123797
+             ],
+             [
+              -75.721556,
+              36.121797
+             ],
+             [
+              -75.723556,
+              36.121797
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 4,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.723138,
+              36.120883
+             ],
+             [
+              -75.723138,
+              36.122883
+             ],
+             [
+              -75.721138,
+              36.122883
+             ],
+             [
+              -75.721138,
+              36.120883
+             ],
+             [
+              -75.723138,
+              36.120883
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 5,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.72271,
+              36.119973
+             ],
+             [
+              -75.72271,
+              36.121973
+             ],
+             [
+              -75.72071,
+              36.121973
+             ],
+             [
+              -75.72071,
+              36.119973
+             ],
+             [
+              -75.72271,
+              36.119973
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 6,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.722277,
+              36.119066
+             ],
+             [
+              -75.722277,
+              36.121066
+             ],
+             [
+              -75.720277,
+              36.121066
+             ],
+             [
+              -75.720277,
+              36.119066
+             ],
+             [
+              -75.722277,
+              36.119066
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 7,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.721845,
+              36.118158
+             ],
+             [
+              -75.721845,
+              36.120158
+             ],
+             [
+              -75.719845,
+              36.120158
+             ],
+             [
+              -75.719845,
+              36.118158
+             ],
+             [
+              -75.721845,
+              36.118158
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 8,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.721413,
+              36.11725
+             ],
+             [
+              -75.721413,
+              36.11925
+             ],
+             [
+              -75.719413,
+              36.11925
+             ],
+             [
+              -75.719413,
+              36.11725
+             ],
+             [
+              -75.721413,
+              36.11725
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 9,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.720979,
+              36.116342
+             ],
+             [
+              -75.720979,
+              36.118342
+             ],
+             [
+              -75.718979,
+              36.118342
+             ],
+             [
+              -75.718979,
+              36.116342
+             ],
+             [
+              -75.720979,
+              36.116342
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 10,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.720538,
+              36.115439
+             ],
+             [
+              -75.720538,
+              36.117439
+             ],
+             [
+              -75.718538,
+              36.117439
+             ],
+             [
+              -75.718538,
+              36.115439
+             ],
+             [
+              -75.720538,
+              36.115439
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 11,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.720097,
+              36.114535
+             ],
+             [
+              -75.720097,
+              36.116535
+             ],
+             [
+              -75.718097,
+              36.116535
+             ],
+             [
+              -75.718097,
+              36.114535
+             ],
+             [
+              -75.720097,
+              36.114535
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 12,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.719655,
+              36.113632
+             ],
+             [
+              -75.719655,
+              36.115632
+             ],
+             [
+              -75.717655,
+              36.115632
+             ],
+             [
+              -75.717655,
+              36.113632
+             ],
+             [
+              -75.719655,
+              36.113632
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 13,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.719214,
+              36.112728
+             ],
+             [
+              -75.719214,
+              36.114728
+             ],
+             [
+              -75.717214,
+              36.114728
+             ],
+             [
+              -75.717214,
+              36.112728
+             ],
+             [
+              -75.719214,
+              36.112728
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 14,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.718712,
+              36.111862
+             ],
+             [
+              -75.718712,
+              36.113862
+             ],
+             [
+              -75.716712,
+              36.113862
+             ],
+             [
+              -75.716712,
+              36.111862
+             ],
+             [
+              -75.718712,
+              36.111862
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 15,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.718103,
+              36.111062
+             ],
+             [
+              -75.718103,
+              36.113062
+             ],
+             [
+              -75.716103,
+              36.113062
+             ],
+             [
+              -75.716103,
+              36.111062
+             ],
+             [
+              -75.718103,
+              36.111062
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 16,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.717495,
+              36.110261
+             ],
+             [
+              -75.717495,
+              36.112261
+             ],
+             [
+              -75.715495,
+              36.112261
+             ],
+             [
+              -75.715495,
+              36.110261
+             ],
+             [
+              -75.717495,
+              36.110261
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 17,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.716934,
+              36.109432
+             ],
+             [
+              -75.716934,
+              36.111432
+             ],
+             [
+              -75.714934,
+              36.111432
+             ],
+             [
+              -75.714934,
+              36.109432
+             ],
+             [
+              -75.716934,
+              36.109432
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 18,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.716521,
+              36.108515
+             ],
+             [
+              -75.716521,
+              36.110515
+             ],
+             [
+              -75.714521,
+              36.110515
+             ],
+             [
+              -75.714521,
+              36.108515
+             ],
+             [
+              -75.716521,
+              36.108515
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 19,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.716102,
+              36.107602
+             ],
+             [
+              -75.716102,
+              36.109602
+             ],
+             [
+              -75.714102,
+              36.109602
+             ],
+             [
+              -75.714102,
+              36.107602
+             ],
+             [
+              -75.716102,
+              36.107602
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 20,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.71559,
+              36.106737
+             ],
+             [
+              -75.71559,
+              36.108737
+             ],
+             [
+              -75.71359,
+              36.108737
+             ],
+             [
+              -75.71359,
+              36.106737
+             ],
+             [
+              -75.71559,
+              36.106737
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 21,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.715077,
+              36.105872
+             ],
+             [
+              -75.715077,
+              36.107872
+             ],
+             [
+              -75.713077,
+              36.107872
+             ],
+             [
+              -75.713077,
+              36.105872
+             ],
+             [
+              -75.715077,
+              36.105872
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 22,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.714565,
+              36.105007
+             ],
+             [
+              -75.714565,
+              36.107007
+             ],
+             [
+              -75.712565,
+              36.107007
+             ],
+             [
+              -75.712565,
+              36.105007
+             ],
+             [
+              -75.714565,
+              36.105007
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 23,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.714075,
+              36.104128
+             ],
+             [
+              -75.714075,
+              36.106128
+             ],
+             [
+              -75.712075,
+              36.106128
+             ],
+             [
+              -75.712075,
+              36.104128
+             ],
+             [
+              -75.714075,
+              36.104128
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 24,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.713587,
+              36.103249
+             ],
+             [
+              -75.713587,
+              36.105249
+             ],
+             [
+              -75.711587,
+              36.105249
+             ],
+             [
+              -75.711587,
+              36.103249
+             ],
+             [
+              -75.713587,
+              36.103249
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 25,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.713096,
+              36.102372
+             ],
+             [
+              -75.713096,
+              36.104372
+             ],
+             [
+              -75.711096,
+              36.104372
+             ],
+             [
+              -75.711096,
+              36.102372
+             ],
+             [
+              -75.713096,
+              36.102372
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 26,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.712604,
+              36.101495
+             ],
+             [
+              -75.712604,
+              36.103495
+             ],
+             [
+              -75.710604,
+              36.103495
+             ],
+             [
+              -75.710604,
+              36.101495
+             ],
+             [
+              -75.712604,
+              36.101495
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 27,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.712111,
+              36.100618
+             ],
+             [
+              -75.712111,
+              36.102618
+             ],
+             [
+              -75.710111,
+              36.102618
+             ],
+             [
+              -75.710111,
+              36.100618
+             ],
+             [
+              -75.712111,
+              36.100618
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 28,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.711587,
+              36.09976
+             ],
+             [
+              -75.711587,
+              36.10176
+             ],
+             [
+              -75.709587,
+              36.10176
+             ],
+             [
+              -75.709587,
+              36.09976
+             ],
+             [
+              -75.711587,
+              36.09976
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 29,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.711063,
+              36.098902
+             ],
+             [
+              -75.711063,
+              36.100902
+             ],
+             [
+              -75.709063,
+              36.100902
+             ],
+             [
+              -75.709063,
+              36.098902
+             ],
+             [
+              -75.711063,
+              36.098902
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 30,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.710672,
+              36.097976
+             ],
+             [
+              -75.710672,
+              36.099976
+             ],
+             [
+              -75.708672,
+              36.099976
+             ],
+             [
+              -75.708672,
+              36.097976
+             ],
+             [
+              -75.710672,
+              36.097976
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 31,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.710289,
+              36.097046
+             ],
+             [
+              -75.710289,
+              36.099046
+             ],
+             [
+              -75.708289,
+              36.099046
+             ],
+             [
+              -75.708289,
+              36.097046
+             ],
+             [
+              -75.710289,
+              36.097046
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 32,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.709907,
+              36.096116
+             ],
+             [
+              -75.709907,
+              36.098116
+             ],
+             [
+              -75.707907,
+              36.098116
+             ],
+             [
+              -75.707907,
+              36.096116
+             ],
+             [
+              -75.709907,
+              36.096116
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 33,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.709479,
+              36.09521
+             ],
+             [
+              -75.709479,
+              36.09721
+             ],
+             [
+              -75.707479,
+              36.09721
+             ],
+             [
+              -75.707479,
+              36.09521
+             ],
+             [
+              -75.709479,
+              36.09521
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 34,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.708944,
+              36.094359
+             ],
+             [
+              -75.708944,
+              36.096359
+             ],
+             [
+              -75.706944,
+              36.096359
+             ],
+             [
+              -75.706944,
+              36.094359
+             ],
+             [
+              -75.708944,
+              36.094359
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 35,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.708408,
+              36.093508
+             ],
+             [
+              -75.708408,
+              36.095508
+             ],
+             [
+              -75.706408,
+              36.095508
+             ],
+             [
+              -75.706408,
+              36.093508
+             ],
+             [
+              -75.708408,
+              36.093508
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 36,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.707872,
+              36.092657
+             ],
+             [
+              -75.707872,
+              36.094657
+             ],
+             [
+              -75.705872,
+              36.094657
+             ],
+             [
+              -75.705872,
+              36.092657
+             ],
+             [
+              -75.707872,
+              36.092657
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 37,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.707336,
+              36.091806
+             ],
+             [
+              -75.707336,
+              36.093806
+             ],
+             [
+              -75.705336,
+              36.093806
+             ],
+             [
+              -75.705336,
+              36.091806
+             ],
+             [
+              -75.707336,
+              36.091806
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 38,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.706801,
+              36.090955
+             ],
+             [
+              -75.706801,
+              36.092955
+             ],
+             [
+              -75.704801,
+              36.092955
+             ],
+             [
+              -75.704801,
+              36.090955
+             ],
+             [
+              -75.706801,
+              36.090955
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 39,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.752818,
+              36.122012
+             ],
+             [
+              -75.752818,
+              36.124012
+             ],
+             [
+              -75.750818,
+              36.124012
+             ],
+             [
+              -75.750818,
+              36.122012
+             ],
+             [
+              -75.752818,
+              36.122012
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 40,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.752773,
+              36.122946
+             ],
+             [
+              -75.752773,
+              36.124946
+             ],
+             [
+              -75.750773,
+              36.124946
+             ],
+             [
+              -75.750773,
+              36.122946
+             ],
+             [
+              -75.752773,
+              36.122946
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 41,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.752665,
+              36.123858
+             ],
+             [
+              -75.752665,
+              36.125858
+             ],
+             [
+              -75.750665,
+              36.125858
+             ],
+             [
+              -75.750665,
+              36.123858
+             ],
+             [
+              -75.752665,
+              36.123858
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 42,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.752508,
+              36.121179
+             ],
+             [
+              -75.752508,
+              36.123179
+             ],
+             [
+              -75.750508,
+              36.123179
+             ],
+             [
+              -75.750508,
+              36.121179
+             ],
+             [
+              -75.752508,
+              36.121179
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 43,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.75214,
+              36.124632
+             ],
+             [
+              -75.75214,
+              36.126632
+             ],
+             [
+              -75.75014,
+              36.126632
+             ],
+             [
+              -75.75014,
+              36.124632
+             ],
+             [
+              -75.75214,
+              36.124632
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 44,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.75198,
+              36.120407
+             ],
+             [
+              -75.75198,
+              36.122407
+             ],
+             [
+              -75.74998,
+              36.122407
+             ],
+             [
+              -75.74998,
+              36.120407
+             ],
+             [
+              -75.75198,
+              36.120407
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 45,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.751489,
+              36.119618
+             ],
+             [
+              -75.751489,
+              36.121618
+             ],
+             [
+              -75.749489,
+              36.121618
+             ],
+             [
+              -75.749489,
+              36.119618
+             ],
+             [
+              -75.751489,
+              36.119618
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 46,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.751193,
+              36.118731
+             ],
+             [
+              -75.751193,
+              36.120731
+             ],
+             [
+              -75.749193,
+              36.120731
+             ],
+             [
+              -75.749193,
+              36.118731
+             ],
+             [
+              -75.751193,
+              36.118731
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 47,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.750897,
+              36.117845
+             ],
+             [
+              -75.750897,
+              36.119845
+             ],
+             [
+              -75.748897,
+              36.119845
+             ],
+             [
+              -75.748897,
+              36.117845
+             ],
+             [
+              -75.750897,
+              36.117845
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 48,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.750602,
+              36.116958
+             ],
+             [
+              -75.750602,
+              36.118958
+             ],
+             [
+              -75.748602,
+              36.118958
+             ],
+             [
+              -75.748602,
+              36.116958
+             ],
+             [
+              -75.750602,
+              36.116958
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 49,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.750342,
+              36.11606
+             ],
+             [
+              -75.750342,
+              36.11806
+             ],
+             [
+              -75.748342,
+              36.11806
+             ],
+             [
+              -75.748342,
+              36.11606
+             ],
+             [
+              -75.750342,
+              36.11606
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 50,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.750093,
+              36.115159
+             ],
+             [
+              -75.750093,
+              36.117159
+             ],
+             [
+              -75.748093,
+              36.117159
+             ],
+             [
+              -75.748093,
+              36.115159
+             ],
+             [
+              -75.750093,
+              36.115159
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 51,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.749844,
+              36.114259
+             ],
+             [
+              -75.749844,
+              36.116259
+             ],
+             [
+              -75.747844,
+              36.116259
+             ],
+             [
+              -75.747844,
+              36.114259
+             ],
+             [
+              -75.749844,
+              36.114259
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 52,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.749595,
+              36.113358
+             ],
+             [
+              -75.749595,
+              36.115358
+             ],
+             [
+              -75.747595,
+              36.115358
+             ],
+             [
+              -75.747595,
+              36.113358
+             ],
+             [
+              -75.749595,
+              36.113358
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 53,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.749345,
+              36.112457
+             ],
+             [
+              -75.749345,
+              36.114457
+             ],
+             [
+              -75.747345,
+              36.114457
+             ],
+             [
+              -75.747345,
+              36.112457
+             ],
+             [
+              -75.749345,
+              36.112457
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 54,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.749084,
+              36.11156
+             ],
+             [
+              -75.749084,
+              36.11356
+             ],
+             [
+              -75.747084,
+              36.11356
+             ],
+             [
+              -75.747084,
+              36.11156
+             ],
+             [
+              -75.749084,
+              36.11156
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 55,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.748813,
+              36.110665
+             ],
+             [
+              -75.748813,
+              36.112665
+             ],
+             [
+              -75.746813,
+              36.112665
+             ],
+             [
+              -75.746813,
+              36.110665
+             ],
+             [
+              -75.748813,
+              36.110665
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 56,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.748542,
+              36.109771
+             ],
+             [
+              -75.748542,
+              36.111771
+             ],
+             [
+              -75.746542,
+              36.111771
+             ],
+             [
+              -75.746542,
+              36.109771
+             ],
+             [
+              -75.748542,
+              36.109771
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 57,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.748271,
+              36.108876
+             ],
+             [
+              -75.748271,
+              36.110876
+             ],
+             [
+              -75.746271,
+              36.110876
+             ],
+             [
+              -75.746271,
+              36.108876
+             ],
+             [
+              -75.748271,
+              36.108876
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 58,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.748087,
+              36.10796
+             ],
+             [
+              -75.748087,
+              36.10996
+             ],
+             [
+              -75.746087,
+              36.10996
+             ],
+             [
+              -75.746087,
+              36.10796
+             ],
+             [
+              -75.748087,
+              36.10796
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 59,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.747917,
+              36.107041
+             ],
+             [
+              -75.747917,
+              36.109041
+             ],
+             [
+              -75.745917,
+              36.109041
+             ],
+             [
+              -75.745917,
+              36.107041
+             ],
+             [
+              -75.747917,
+              36.107041
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 60,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.747747,
+              36.106122
+             ],
+             [
+              -75.747747,
+              36.108122
+             ],
+             [
+              -75.745747,
+              36.108122
+             ],
+             [
+              -75.745747,
+              36.106122
+             ],
+             [
+              -75.747747,
+              36.106122
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 61,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.747482,
+              36.105226
+             ],
+             [
+              -75.747482,
+              36.107226
+             ],
+             [
+              -75.745482,
+              36.107226
+             ],
+             [
+              -75.745482,
+              36.105226
+             ],
+             [
+              -75.747482,
+              36.105226
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 62,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.74721,
+              36.104332
+             ],
+             [
+              -75.74721,
+              36.106332
+             ],
+             [
+              -75.74521,
+              36.106332
+             ],
+             [
+              -75.74521,
+              36.104332
+             ],
+             [
+              -75.74721,
+              36.104332
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 63,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.747005,
+              36.103425
+             ],
+             [
+              -75.747005,
+              36.105425
+             ],
+             [
+              -75.745005,
+              36.105425
+             ],
+             [
+              -75.745005,
+              36.103425
+             ],
+             [
+              -75.747005,
+              36.103425
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 64,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746922,
+              36.102494
+             ],
+             [
+              -75.746922,
+              36.104494
+             ],
+             [
+              -75.744922,
+              36.104494
+             ],
+             [
+              -75.744922,
+              36.102494
+             ],
+             [
+              -75.746922,
+              36.102494
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 65,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.74684,
+              36.101563
+             ],
+             [
+              -75.74684,
+              36.103563
+             ],
+             [
+              -75.74484,
+              36.103563
+             ],
+             [
+              -75.74484,
+              36.101563
+             ],
+             [
+              -75.74684,
+              36.101563
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 66,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746757,
+              36.100632
+             ],
+             [
+              -75.746757,
+              36.102632
+             ],
+             [
+              -75.744757,
+              36.102632
+             ],
+             [
+              -75.744757,
+              36.100632
+             ],
+             [
+              -75.746757,
+              36.100632
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 67,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746674,
+              36.099701
+             ],
+             [
+              -75.746674,
+              36.101701
+             ],
+             [
+              -75.744674,
+              36.101701
+             ],
+             [
+              -75.744674,
+              36.099701
+             ],
+             [
+              -75.746674,
+              36.099701
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 68,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746466,
+              36.098798
+             ],
+             [
+              -75.746466,
+              36.100798
+             ],
+             [
+              -75.744466,
+              36.100798
+             ],
+             [
+              -75.744466,
+              36.098798
+             ],
+             [
+              -75.746466,
+              36.098798
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 69,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746143,
+              36.097921
+             ],
+             [
+              -75.746143,
+              36.099921
+             ],
+             [
+              -75.744143,
+              36.099921
+             ],
+             [
+              -75.744143,
+              36.097921
+             ],
+             [
+              -75.746143,
+              36.097921
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 70,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.74582,
+              36.097044
+             ],
+             [
+              -75.74582,
+              36.099044
+             ],
+             [
+              -75.74382,
+              36.099044
+             ],
+             [
+              -75.74382,
+              36.097044
+             ],
+             [
+              -75.74582,
+              36.097044
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 71,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.745496,
+              36.096167
+             ],
+             [
+              -75.745496,
+              36.098167
+             ],
+             [
+              -75.743496,
+              36.098167
+             ],
+             [
+              -75.743496,
+              36.096167
+             ],
+             [
+              -75.745496,
+              36.096167
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 72,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.745158,
+              36.095296
+             ],
+             [
+              -75.745158,
+              36.097296
+             ],
+             [
+              -75.743158,
+              36.097296
+             ],
+             [
+              -75.743158,
+              36.095296
+             ],
+             [
+              -75.745158,
+              36.095296
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 73,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.744753,
+              36.094454
+             ],
+             [
+              -75.744753,
+              36.096454
+             ],
+             [
+              -75.742753,
+              36.096454
+             ],
+             [
+              -75.742753,
+              36.094454
+             ],
+             [
+              -75.744753,
+              36.094454
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 74,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.744349,
+              36.093611
+             ],
+             [
+              -75.744349,
+              36.095611
+             ],
+             [
+              -75.742349,
+              36.095611
+             ],
+             [
+              -75.742349,
+              36.093611
+             ],
+             [
+              -75.744349,
+              36.093611
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 75,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.744009,
+              36.092749
+             ],
+             [
+              -75.744009,
+              36.094749
+             ],
+             [
+              -75.742009,
+              36.094749
+             ],
+             [
+              -75.742009,
+              36.092749
+             ],
+             [
+              -75.744009,
+              36.092749
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 76,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.743893,
+              36.091822
+             ],
+             [
+              -75.743893,
+              36.093822
+             ],
+             [
+              -75.741893,
+              36.093822
+             ],
+             [
+              -75.741893,
+              36.091822
+             ],
+             [
+              -75.743893,
+              36.091822
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 77,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.743627,
+              36.09094
+             ],
+             [
+              -75.743627,
+              36.09294
+             ],
+             [
+              -75.741627,
+              36.09294
+             ],
+             [
+              -75.741627,
+              36.09094
+             ],
+             [
+              -75.743627,
+              36.09094
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 78,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.743209,
+              36.090104
+             ],
+             [
+              -75.743209,
+              36.092104
+             ],
+             [
+              -75.741209,
+              36.092104
+             ],
+             [
+              -75.741209,
+              36.090104
+             ],
+             [
+              -75.743209,
+              36.090104
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 79,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.750038,
+              36.125405
+             ],
+             [
+              -75.750038,
+              36.127405
+             ],
+             [
+              -75.748038,
+              36.127405
+             ],
+             [
+              -75.748038,
+              36.125405
+             ],
+             [
+              -75.750038,
+              36.125405
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 80,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.749405,
+              36.12449
+             ],
+             [
+              -75.749405,
+              36.12649
+             ],
+             [
+              -75.747405,
+              36.12649
+             ],
+             [
+              -75.747405,
+              36.12449
+             ],
+             [
+              -75.749405,
+              36.12449
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 81,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.748888,
+              36.123517
+             ],
+             [
+              -75.748888,
+              36.125517
+             ],
+             [
+              -75.746888,
+              36.125517
+             ],
+             [
+              -75.746888,
+              36.123517
+             ],
+             [
+              -75.748888,
+              36.123517
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 82,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.748536,
+              36.122462
+             ],
+             [
+              -75.748536,
+              36.124462
+             ],
+             [
+              -75.746536,
+              36.124462
+             ],
+             [
+              -75.746536,
+              36.122462
+             ],
+             [
+              -75.748536,
+              36.122462
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 83,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.748243,
+              36.121389
+             ],
+             [
+              -75.748243,
+              36.123389
+             ],
+             [
+              -75.746243,
+              36.123389
+             ],
+             [
+              -75.746243,
+              36.121389
+             ],
+             [
+              -75.748243,
+              36.121389
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 84,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.747973,
+              36.12031
+             ],
+             [
+              -75.747973,
+              36.12231
+             ],
+             [
+              -75.745973,
+              36.12231
+             ],
+             [
+              -75.745973,
+              36.12031
+             ],
+             [
+              -75.747973,
+              36.12031
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 85,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.747703,
+              36.119231
+             ],
+             [
+              -75.747703,
+              36.121231
+             ],
+             [
+              -75.745703,
+              36.121231
+             ],
+             [
+              -75.745703,
+              36.119231
+             ],
+             [
+              -75.747703,
+              36.119231
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 86,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.747433,
+              36.118151
+             ],
+             [
+              -75.747433,
+              36.120151
+             ],
+             [
+              -75.745433,
+              36.120151
+             ],
+             [
+              -75.745433,
+              36.118151
+             ],
+             [
+              -75.747433,
+              36.118151
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 87,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.747164,
+              36.117072
+             ],
+             [
+              -75.747164,
+              36.119072
+             ],
+             [
+              -75.745164,
+              36.119072
+             ],
+             [
+              -75.745164,
+              36.117072
+             ],
+             [
+              -75.747164,
+              36.117072
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 88,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746894,
+              36.115993
+             ],
+             [
+              -75.746894,
+              36.117993
+             ],
+             [
+              -75.744894,
+              36.117993
+             ],
+             [
+              -75.744894,
+              36.115993
+             ],
+             [
+              -75.746894,
+              36.115993
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 89,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746624,
+              36.114914
+             ],
+             [
+              -75.746624,
+              36.116914
+             ],
+             [
+              -75.744624,
+              36.116914
+             ],
+             [
+              -75.744624,
+              36.114914
+             ],
+             [
+              -75.746624,
+              36.114914
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 90,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746354,
+              36.113834
+             ],
+             [
+              -75.746354,
+              36.115834
+             ],
+             [
+              -75.744354,
+              36.115834
+             ],
+             [
+              -75.744354,
+              36.113834
+             ],
+             [
+              -75.746354,
+              36.113834
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 91,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.746055,
+              36.112765
+             ],
+             [
+              -75.746055,
+              36.114765
+             ],
+             [
+              -75.744055,
+              36.114765
+             ],
+             [
+              -75.744055,
+              36.112765
+             ],
+             [
+              -75.746055,
+              36.112765
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 92,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.74563,
+              36.111737
+             ],
+             [
+              -75.74563,
+              36.113737
+             ],
+             [
+              -75.74363,
+              36.113737
+             ],
+             [
+              -75.74363,
+              36.111737
+             ],
+             [
+              -75.74563,
+              36.111737
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 93,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.745272,
+              36.122161
+             ],
+             [
+              -75.745272,
+              36.124161
+             ],
+             [
+              -75.743272,
+              36.124161
+             ],
+             [
+              -75.743272,
+              36.122161
+             ],
+             [
+              -75.745272,
+              36.122161
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 94,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.745205,
+              36.110709
+             ],
+             [
+              -75.745205,
+              36.112709
+             ],
+             [
+              -75.743205,
+              36.112709
+             ],
+             [
+              -75.743205,
+              36.110709
+             ],
+             [
+              -75.745205,
+              36.110709
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 95,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.745127,
+              36.123239
+             ],
+             [
+              -75.745127,
+              36.125239
+             ],
+             [
+              -75.743127,
+              36.125239
+             ],
+             [
+              -75.743127,
+              36.123239
+             ],
+             [
+              -75.745127,
+              36.123239
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 96,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.74493,
+              36.121102
+             ],
+             [
+              -75.74493,
+              36.123102
+             ],
+             [
+              -75.74293,
+              36.123102
+             ],
+             [
+              -75.74293,
+              36.121102
+             ],
+             [
+              -75.74493,
+              36.121102
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 97,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.744872,
+              36.124322
+             ],
+             [
+              -75.744872,
+              36.126322
+             ],
+             [
+              -75.742872,
+              36.126322
+             ],
+             [
+              -75.742872,
+              36.124322
+             ],
+             [
+              -75.744872,
+              36.124322
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 98,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.744806,
+              36.109671
+             ],
+             [
+              -75.744806,
+              36.111671
+             ],
+             [
+              -75.742806,
+              36.111671
+             ],
+             [
+              -75.742806,
+              36.109671
+             ],
+             [
+              -75.744806,
+              36.109671
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 99,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.744588,
+              36.120043
+             ],
+             [
+              -75.744588,
+              36.122043
+             ],
+             [
+              -75.742588,
+              36.122043
+             ],
+             [
+              -75.742588,
+              36.120043
+             ],
+             [
+              -75.744588,
+              36.120043
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 100,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.744454,
+              36.108615
+             ],
+             [
+              -75.744454,
+              36.110615
+             ],
+             [
+              -75.742454,
+              36.110615
+             ],
+             [
+              -75.742454,
+              36.108615
+             ],
+             [
+              -75.744454,
+              36.108615
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 101,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.744251,
+              36.118983
+             ],
+             [
+              -75.744251,
+              36.120983
+             ],
+             [
+              -75.742251,
+              36.120983
+             ],
+             [
+              -75.742251,
+              36.118983
+             ],
+             [
+              -75.744251,
+              36.118983
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 102,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.744103,
+              36.10756
+             ],
+             [
+              -75.744103,
+              36.10956
+             ],
+             [
+              -75.742103,
+              36.10956
+             ],
+             [
+              -75.742103,
+              36.10756
+             ],
+             [
+              -75.744103,
+              36.10756
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 103,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.743923,
+              36.11792
+             ],
+             [
+              -75.743923,
+              36.11992
+             ],
+             [
+              -75.741923,
+              36.11992
+             ],
+             [
+              -75.741923,
+              36.11792
+             ],
+             [
+              -75.743923,
+              36.11792
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 104,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.743596,
+              36.116857
+             ],
+             [
+              -75.743596,
+              36.118857
+             ],
+             [
+              -75.741596,
+              36.118857
+             ],
+             [
+              -75.741596,
+              36.116857
+             ],
+             [
+              -75.743596,
+              36.116857
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 105,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.743551,
+              36.106619
+             ],
+             [
+              -75.743551,
+              36.108619
+             ],
+             [
+              -75.741551,
+              36.108619
+             ],
+             [
+              -75.741551,
+              36.106619
+             ],
+             [
+              -75.743551,
+              36.106619
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 106,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.743445,
+              36.115758
+             ],
+             [
+              -75.743445,
+              36.117758
+             ],
+             [
+              -75.741445,
+              36.117758
+             ],
+             [
+              -75.741445,
+              36.115758
+             ],
+             [
+              -75.743445,
+              36.115758
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 107,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.743334,
+              36.114651
+             ],
+             [
+              -75.743334,
+              36.116651
+             ],
+             [
+              -75.741334,
+              36.116651
+             ],
+             [
+              -75.741334,
+              36.114651
+             ],
+             [
+              -75.743334,
+              36.114651
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 108,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.743188,
+              36.113553
+             ],
+             [
+              -75.743188,
+              36.115553
+             ],
+             [
+              -75.741188,
+              36.115553
+             ],
+             [
+              -75.741188,
+              36.113553
+             ],
+             [
+              -75.743188,
+              36.113553
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 109,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.742816,
+              36.105784
+             ],
+             [
+              -75.742816,
+              36.107784
+             ],
+             [
+              -75.740816,
+              36.107784
+             ],
+             [
+              -75.740816,
+              36.105784
+             ],
+             [
+              -75.742816,
+              36.105784
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 110,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.742724,
+              36.112542
+             ],
+             [
+              -75.742724,
+              36.114542
+             ],
+             [
+              -75.740724,
+              36.114542
+             ],
+             [
+              -75.740724,
+              36.112542
+             ],
+             [
+              -75.742724,
+              36.112542
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 111,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.742261,
+              36.111531
+             ],
+             [
+              -75.742261,
+              36.113531
+             ],
+             [
+              -75.740261,
+              36.113531
+             ],
+             [
+              -75.740261,
+              36.111531
+             ],
+             [
+              -75.742261,
+              36.111531
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 112,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.742081,
+              36.104949
+             ],
+             [
+              -75.742081,
+              36.106949
+             ],
+             [
+              -75.740081,
+              36.106949
+             ],
+             [
+              -75.740081,
+              36.104949
+             ],
+             [
+              -75.742081,
+              36.104949
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 113,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.741856,
+              36.110495
+             ],
+             [
+              -75.741856,
+              36.112495
+             ],
+             [
+              -75.739856,
+              36.112495
+             ],
+             [
+              -75.739856,
+              36.110495
+             ],
+             [
+              -75.741856,
+              36.110495
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 114,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.741625,
+              36.105134
+             ],
+             [
+              -75.741625,
+              36.107134
+             ],
+             [
+              -75.739625,
+              36.107134
+             ],
+             [
+              -75.739625,
+              36.105134
+             ],
+             [
+              -75.741625,
+              36.105134
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 115,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.741473,
+              36.109451
+             ],
+             [
+              -75.741473,
+              36.111451
+             ],
+             [
+              -75.739473,
+              36.111451
+             ],
+             [
+              -75.739473,
+              36.109451
+             ],
+             [
+              -75.741473,
+              36.109451
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 116,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.741418,
+              36.106227
+             ],
+             [
+              -75.741418,
+              36.108227
+             ],
+             [
+              -75.739418,
+              36.108227
+             ],
+             [
+              -75.739418,
+              36.106227
+             ],
+             [
+              -75.741418,
+              36.106227
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 117,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.741211,
+              36.10732
+             ],
+             [
+              -75.741211,
+              36.10932
+             ],
+             [
+              -75.739211,
+              36.10932
+             ],
+             [
+              -75.739211,
+              36.10732
+             ],
+             [
+              -75.741211,
+              36.10732
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 118,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         },
+         {
+          "geometry": {
+           "coordinates": [
+            [
+             [
+              -75.74109,
+              36.108406
+             ],
+             [
+              -75.74109,
+              36.110406
+             ],
+             [
+              -75.73909,
+              36.110406
+             ],
+             [
+              -75.73909,
+              36.108406
+             ],
+             [
+              -75.74109,
+              36.108406
+             ]
+            ]
+           ],
+           "type": "Polygon"
+          },
+          "properties": {
+           "id": 119,
+           "style": {
+            "color": "grey",
+            "fillColor": "grey",
+            "fillOpacity": 0.2,
+            "weight": 1
+           }
+          },
+          "type": "Feature"
+         }
+        ],
+        "type": "FeatureCollection"
+       },
+       "hover_style": {
+        "fillColor": "red"
+       },
+       "name": "ROIs"
+      }
+     },
+     "ebb2ed411565430ab7589b30a4c1d11f": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_8f659a2866844fc09bce5a45207377eb",
+       "style": "IPY_MODEL_379f6591c6914606aea126e6e4980cb5",
+       "value": "Location:(-75.71552137788503,36.10951545863337)"
+      }
+     },
+     "ebd4d24fd9104aaaaef305f7acf3e1f9": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ec1668f55bea4102ae2dac51e73f9db3": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Tiles courtesy of the U.S. Geological Survey",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "USGS.USImagery",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryOnly/MapServer/tile/{z}/{y}/{x}"
+      }
+     },
+     "ec3f06bf9cde4902b15e730233570231": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ec930c8c9e454287a054074798f10b26": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.126405,
+        -75.72432853888888
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_2854e4d1b50d4c729266cdd7334e1370",
+       "title": "Location:(-75.72432853888888,36.126405)"
+      }
+     },
+     "eceabdbe0e6f49cc956ec5e47aa8c4a3": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ed4bbd2a2d564f4bb840e9f878164146": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.101618036180724,
+        -75.71111146488822
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_6c49db5c1e12413bbcda5cdd6c25c31f",
+       "title": "Location:(-75.71111146488822,36.101618036180724)"
+      }
+     },
+     "eda6325a46a54c55b0a1b0d004a85c46": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.113764579034104,
+        -75.7450554030486
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_4e25afe8e77a4e3bae577c95f577392e",
+       "title": "Location:(-75.7450554030486,36.113764579034104)"
+      }
+     },
+     "edcadeebab034e36a1d117a6d762d419": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "eeb6acbed66a4f9fb1198434eaa5eee4": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_2c7a0f73dd91410ba5f964b8b32975fe",
+       "style": "IPY_MODEL_abadc1574c0b4d36afce5fc72b3d58c6",
+       "value": "Location:(-75.74884381357502,36.11525863292509)"
+      }
+     },
+     "ef13578828344b20b0e7789cb09b87ce": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.093749442705736,
+        -75.74300871497711
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_5d71560731c9400490e62db164aab28c",
+       "title": "Location:(-75.74300871497711,36.093749442705736)"
+      }
+     },
+     "efcf759b506f4674bc2e94f590967ede": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f0140cd2d84347ba83e7735293c6181e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f120a05d21fe40bca496d69d2199bf8a": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "![](https://docs.onemap.sg/maps/images/oneMap64-01.png) New OneMap | Map data (C) contributors, Singapore Land Authority",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "OneMapSG.Grey",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://maps-a.onemap.sg/v3/Grey/{z}/{x}/{y}.png"
+      }
+     },
+     "f13ecefd1ba64dd390890c383cc8e372": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f14118e294c541ccb6eb648b4c92e632": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f17b31a5c75e4d5aad82bafbd95208c2": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.11043243095848,
+        -75.71593401543133
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_28e61cd0f1ce429f9f866d3d148ca2e9",
+       "title": "Location:(-75.71593401543133,36.11043243095848)"
+      }
+     },
+     "f1c14ac4983742f1964cfa73be207f9e": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "height": "auto",
+       "padding": "0px 0px 0px 4px",
+       "width": "auto"
+      }
+     },
+     "f2c224446f114f47a5ea768ec1543522": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_f8f1ecb5837b4ed5881c7f5754a0ae58",
+       "style": "IPY_MODEL_63b7428d2e72472ca6270afbb5180d7c",
+       "value": "Location:(-75.72084495141614,36.11915767797389)"
+      }
+     },
+     "f3301a2241444a528a7fca09aebbe693": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.09461094444164,
+        -75.74334900263659
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_14914602f334433b99cc532908951c99",
+       "title": "Location:(-75.74334900263659,36.09461094444164)"
+      }
+     },
+     "f35a272f65ce4918880eb3b5f6aca37d": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Tiles (C) Esri -- Source: Esri, DeLorme, NAVTEQ, USGS, Intermap, iPC, NRCAN, Esri Japan, METI, Esri China (Hong Kong), Esri (Thailand), TomTom, 2012",
+       "max_native_zoom": 18,
+       "max_zoom": 22,
+       "min_native_zoom": 0,
+       "name": "Esri.WorldStreetMap",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}"
+      }
+     },
+     "f38a28c19ab949638728c484978b9374": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_9d119dae02864db99a8432dbcca5f1b7",
+       "style": "IPY_MODEL_3cc3e99436b74083becefb5202561eb9",
+       "value": "Location:(-75.74788830111393,36.12451713334178)"
+      }
+     },
+     "f3f323eed1fa44c2b4f9f95d57ad5f52": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "height": "28px",
+       "width": "72px"
+      }
+     },
+     "f437c9276c5f4bd3881db6e1c07073a2": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "(C) OpenStreetMap contributors (C) CARTO",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "CartoDB.Positron",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png"
+      }
+     },
+     "f4384908e57549579be1c28c9e94eab7": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.11286249212666,
+        -75.71771163921626
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_473b8492e9f340ccbbd3c26296901421",
+       "title": "Location:(-75.71771163921626,36.11286249212666)"
+      }
+     },
+     "f45d084eed4d453da3847dcb75d6abb6": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_2456040df2e34673b78473655b317d45",
+       "style": "IPY_MODEL_166d80b82c1f4f0a804c6cc6fde436ec",
+       "value": "Location:(-75.71510249837408,36.10860172725625)"
+      }
+     },
+     "f4c212480ee74ade9bdd45b6a823b176": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_5f2c155c083c4ba4a852b80a84381f13",
+       "style": "IPY_MODEL_93717828a3dd493aaf28f5ec982c9454",
+       "value": "Location:(-75.7498974842412,36.118844682723626)"
+      }
+     },
+     "f503d7bf72a742a9bc3d55bf2ec9b294": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f5a74e94d95c4b79825f2eacddebbc75": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f6144c08db7b4c10ab426bc8c308773f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f692e5f835774e5ab55df7ce3ffd2aed": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+       "max_native_zoom": 18,
+       "max_zoom": 9,
+       "min_native_zoom": 0,
+       "name": "NASAGIBS.ModisAquaBands721CR",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/MODIS_Aqua_CorrectedReflectance_Bands721/default//GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg"
+      }
+     },
+     "f6d38d5154f84e59814c5af5c1744bad": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map tiles by Stamen Design, CC BY 3.0 -- Map data (C) OpenStreetMap contributors",
+       "max_native_zoom": 18,
+       "max_zoom": 20,
+       "min_native_zoom": 0,
+       "name": "Stamen.TonerHybrid",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://stamen-tiles-a.a.ssl.fastly.net/toner-hybrid/{z}/{x}/{y}.png"
+      }
+     },
+     "f711a4e504004927bc6837cfc4e67459": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.121407404983266,
+        -75.75098038288328
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_23499d0a3d1b4484a6cba35ea47b22dd",
+       "title": "Location:(-75.75098038288328,36.121407404983266)"
+      }
+     },
+     "f75e84c299f0454c834c4b69bc569765": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.10256275035493,
+        -75.74583957086048
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_a5962110784442559813ad900f50901e",
+       "title": "Location:(-75.74583957086048,36.10256275035493)"
+      }
+     },
+     "f7f272db34974a218507acebbe851c10": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f817144a827d4b4db4f5932ec80fd79f": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f856428ec51544d4bd1ad1815b9cde43": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Imagery provided by services from the Global Imagery Browse Services (GIBS), operated by the NASA/GSFC/Earth Science Data and Information System (<a href=\"https://earthdata.nasa.gov\">ESDIS</a>) with funding provided by NASA/HQ.",
+       "max_native_zoom": 18,
+       "max_zoom": 9,
+       "min_native_zoom": 0,
+       "name": "NASAGIBS.ViirsTrueColorCR",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/VIIRS_SNPP_CorrectedReflectance_TrueColor/default//GoogleMapsCompatible_Level9/{z}/{y}/{x}.jpg"
+      }
+     },
+     "f8b231a062d8483b82ac207ce8536586": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "HTMLModel",
+      "state": {
+       "layout": "IPY_MODEL_9cbcab14b24241caad14ae77e3b85325",
+       "style": "IPY_MODEL_ccb584ba418243b0a3a9e9bdd608032a",
+       "value": "Location:(-75.70580065656158,36.091954919833086)"
+      }
+     },
+     "f8ef4388250945c2b55e26553feb108f": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Tiles (C) Esri -- Copyright: (C)2012 DeLorme",
+       "max_native_zoom": 18,
+       "max_zoom": 11,
+       "min_native_zoom": 0,
+       "name": "Esri.DeLorme",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://server.arcgisonline.com/ArcGIS/rest/services/Specialty/DeLorme_World_Base_Map/MapServer/tile/{z}/{y}/{x}"
+      }
+     },
+     "f8f1ecb5837b4ed5881c7f5754a0ae58": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f914c16de07e49d4baf5e2c8f38917f1": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "f924325ff04e4cbd9f61ef62225a43c3": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "![](https://docs.onemap.sg/maps/images/oneMap64-01.png) New OneMap | Map data (C) contributors, Singapore Land Authority",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "OneMapSG.Night",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://maps-a.onemap.sg/v3/Night/{z}/{x}/{y}.png"
+      }
+     },
+     "fa5418b5aa51448399b334631a012bf2": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "height": "auto",
+       "padding": "0px 0px 0px 4px",
+       "width": "auto"
+      }
+     },
+     "fa95ab5137ac48feaa46828eaecdda29": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {
+       "height": "600px",
+       "width": "100%"
+      }
+     },
+     "fb2fe24855804e9ab0098956c1b87215": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map data: (C) OpenStreetMap contributors | Map style: (C) waymarkedtrails.org (CC-BY-SA)",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "WaymarkedTrails.hiking",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://tile.waymarkedtrails.org/hiking/{z}/{x}/{y}.png"
+      }
+     },
+     "fba084cbc14a4de8b1fd1c0a0df7d779": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletWMSLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "FWS",
+       "crs": {
+        "custom": false,
+        "name": "EPSG3857"
+       },
+       "format": "image/png",
+       "layers": "1",
+       "max_native_zoom": 18,
+       "min_native_zoom": 0,
+       "name": "FWS NWI Wetlands",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "format",
+        "layers",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "styles",
+        "tile_size",
+        "tms",
+        "transparent",
+        "uppercase"
+       ],
+       "transparent": true,
+       "url": "https://www.fws.gov/wetlands/arcgis/services/Wetlands/MapServer/WMSServer?"
+      }
+     },
+     "fd0945b2d9b34cf7b4edf0a4b6d24964": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.11915148265106,
+        -75.74643343816277
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_d053093e63064c6cab44759d9d4bad72",
+       "title": "Location:(-75.74643343816277,36.11915148265106)"
+      }
+     },
+     "fd0f883b0b2b431da058386d0156aadd": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.12301212526756,
+        -75.75181752641937
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_c65138f42e4b4ecbb3e514765f66a69b",
+       "title": "Location:(-75.75181752641937,36.12301212526756)"
+      }
+     },
+     "fd9b1599821a4314b01d741a33e579b3": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletMarkerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "draggable": false,
+       "location": [
+        36.10249452547738,
+        -75.71160422546734
+       ],
+       "options": [
+        "alt",
+        "draggable",
+        "keyboard",
+        "rise_offset",
+        "rise_on_hover",
+        "rotation_angle",
+        "rotation_origin",
+        "title",
+        "z_index_offset"
+       ],
+       "popup": "IPY_MODEL_371b9dd1a875428f8875c656d9f28fb6",
+       "title": "Location:(-75.71160422546734,36.10249452547738)"
+      }
+     },
+     "fe9fe923fe37452ab93f6d7402bce99a": {
+      "model_module": "@jupyter-widgets/controls",
+      "model_module_version": "1.5.0",
+      "model_name": "DescriptionStyleModel",
+      "state": {
+       "description_width": ""
+      }
+     },
+     "fec74fe8ff3b4bba944bf1f7ab2c091d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "1.2.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "ffd4ba31b972465bae36dec8ddef6de6": {
+      "model_module": "jupyter-leaflet",
+      "model_module_version": "^0.15.0",
+      "model_name": "LeafletTileLayerModel",
+      "state": {
+       "_model_module_version": "^0.15.0",
+       "_view_module_version": "^0.15.0",
+       "attribution": "Map data: (C) OpenStreetMap contributors | Map style: (C) OpenRailwayMap (CC-BY-SA)",
+       "max_native_zoom": 18,
+       "max_zoom": 19,
+       "min_native_zoom": 0,
+       "name": "OpenRailwayMap",
+       "options": [
+        "attribution",
+        "detect_retina",
+        "max_native_zoom",
+        "max_zoom",
+        "min_native_zoom",
+        "min_zoom",
+        "no_wrap",
+        "tile_size",
+        "tms"
+       ],
+       "url": "https://a.tiles.openrailwaymap.org/standard/{z}/{x}/{y}.png"
+      }
+     }
+    },
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/coastsat/SDS_classify.py
+++ b/notebooks/coastsat/SDS_classify.py
@@ -1,0 +1,642 @@
+"""
+This module contains functions to label satellite images, use the labels to 
+train a pixel-wise classifier and evaluate the classifier
+
+Author: Kilian Vos, Water Research Laboratory, University of New South Wales
+"""
+
+# load modules
+import os
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.cm as cm
+from matplotlib.widgets import LassoSelector
+from matplotlib import path
+import pickle
+import pdb
+import warnings
+warnings.filterwarnings("ignore")
+
+# image processing modules
+from skimage.segmentation import flood
+from skimage import morphology
+from pylab import ginput
+from sklearn.metrics import confusion_matrix
+np.set_printoptions(precision=2)
+
+# CoastSat modules
+from coastsat import SDS_preprocess, SDS_shoreline, SDS_tools
+
+class SelectFromImage(object):
+    """
+    Class used to draw the lassos on the images with two methods:
+        - onselect: save the pixels inside the selection
+        - disconnect: stop drawing lassos on the image
+    """
+    # initialize lasso selection class
+    def __init__(self, ax, implot, color=[1,1,1]):
+        self.canvas = ax.figure.canvas
+        self.implot = implot
+        self.array = implot.get_array()
+        xv, yv = np.meshgrid(np.arange(self.array.shape[1]),np.arange(self.array.shape[0]))
+        self.pix = np.vstack( (xv.flatten(), yv.flatten()) ).T
+        self.ind = []
+        self.im_bool = np.zeros((self.array.shape[0], self.array.shape[1]))
+        self.color = color
+        self.lasso = LassoSelector(ax, onselect=self.onselect)
+
+    def onselect(self, verts):
+        # find pixels contained in the lasso
+        p = path.Path(verts)
+        self.ind = p.contains_points(self.pix, radius=1)
+        # color selected pixels
+        array_list = []
+        for k in range(self.array.shape[2]):
+            array2d = self.array[:,:,k]    
+            lin = np.arange(array2d.size)
+            new_array2d = array2d.flatten()
+            new_array2d[lin[self.ind]] = self.color[k]
+            array_list.append(new_array2d.reshape(array2d.shape))
+        self.array = np.stack(array_list,axis=2)
+        self.implot.set_data(self.array)
+        self.canvas.draw_idle()
+        # update boolean image with selected pixels
+        vec_bool = self.im_bool.flatten()
+        vec_bool[lin[self.ind]] = 1
+        self.im_bool = vec_bool.reshape(self.im_bool.shape)
+
+    def disconnect(self):
+        self.lasso.disconnect_events()
+
+def label_images(metadata,settings):
+    """
+    Load satellite images and interactively label different classes (hard-coded)
+
+    KV WRL 2019
+
+    Arguments:
+    -----------
+    metadata: dict
+        contains all the information about the satellite images that were downloaded
+    settings: dict with the following keys
+        'cloud_thresh': float
+            value between 0 and 1 indicating the maximum cloud fraction in 
+            the cropped image that is accepted    
+        'cloud_mask_issue': boolean
+            True if there is an issue with the cloud mask and sand pixels
+            are erroneously being masked on the images
+        'labels': dict
+            list of label names (key) and label numbers (value) for each class
+        'flood_fill': boolean
+            True to use the flood_fill functionality when labelling sand pixels
+        'tolerance': float
+            tolerance value for flood fill when labelling the sand pixels
+        'filepath_train': str
+            directory in which to save the labelled data
+        'inputs': dict
+            input parameters (sitename, filepath, polygon, dates, sat_list)
+                
+    Returns:
+    -----------
+    Stores the labelled data in the specified directory
+
+    """
+    
+    filepath_train = settings['filepath_train']
+    # initialize figure
+    fig,ax = plt.subplots(1,1,figsize=[17,10], tight_layout=True,sharex=True,
+                          sharey=True)
+    mng = plt.get_current_fig_manager()                                         
+    mng.window.showMaximized()
+
+    # loop through satellites
+    for satname in metadata.keys():
+        filepath = SDS_tools.get_filepath(settings['inputs'],satname)
+        filenames = metadata[satname]['filenames']
+        # loop through images
+        for i in range(len(filenames)):
+            # image filename
+            fn = SDS_tools.get_filenames(filenames[i],filepath, satname)
+            # read and preprocess image
+            im_ms, georef, cloud_mask, im_extra, im_QA, im_nodata = SDS_preprocess.preprocess_single(fn, satname, settings['cloud_mask_issue'])
+
+            # compute cloud_cover percentage (with no data pixels)
+            cloud_cover_combined = np.divide(sum(sum(cloud_mask.astype(int))),
+                                    (cloud_mask.shape[0]*cloud_mask.shape[1]))
+            if cloud_cover_combined > 0.99: # if 99% of cloudy pixels in image skip
+                continue
+
+            # remove no data pixels from the cloud mask (for example L7 bands of no data should not be accounted for)
+            cloud_mask_adv = np.logical_xor(cloud_mask, im_nodata)
+            # compute updated cloud cover percentage (without no data pixels)
+            cloud_cover = np.divide(sum(sum(cloud_mask_adv.astype(int))),
+                                    (sum(sum((~im_nodata).astype(int)))))
+            # skip image if cloud cover is above threshold
+            if cloud_cover > settings['cloud_thresh'] or cloud_cover == 1:
+                continue
+            # get individual RGB image
+            im_RGB = SDS_preprocess.rescale_image_intensity(im_ms[:,:,[2,1,0]], cloud_mask, 99.9)
+            im_NDVI = SDS_tools.nd_index(im_ms[:,:,3], im_ms[:,:,2], cloud_mask)
+            im_NDWI = SDS_tools.nd_index(im_ms[:,:,3], im_ms[:,:,1], cloud_mask)
+            # initialise labels
+            im_viz = im_RGB.copy()
+            im_labels = np.zeros([im_RGB.shape[0],im_RGB.shape[1]])
+            # show RGB image
+            ax.axis('off')  
+            ax.imshow(im_RGB)
+            implot = ax.imshow(im_viz, alpha=0.6)            
+            filename = filenames[i][:filenames[i].find('.')][:-4] 
+            ax.set_title(filename)
+           
+            ##############################################################
+            # select image to label
+            ##############################################################           
+            # set a key event to accept/reject the detections (see https://stackoverflow.com/a/15033071)
+            # this variable needs to be immuatable so we can access it after the keypress event
+            key_event = {}
+            def press(event):
+                # store what key was pressed in the dictionary
+                key_event['pressed'] = event.key
+            # let the user press a key, right arrow to keep the image, left arrow to skip it
+            # to break the loop the user can press 'escape'
+            while True:
+                btn_keep = ax.text(1.1, 0.9, 'keep ⇨', size=12, ha="right", va="top",
+                                    transform=ax.transAxes,
+                                    bbox=dict(boxstyle="square", ec='k',fc='w'))
+                btn_skip = ax.text(-0.1, 0.9, '⇦ skip', size=12, ha="left", va="top",
+                                    transform=ax.transAxes,
+                                    bbox=dict(boxstyle="square", ec='k',fc='w'))
+                btn_esc = ax.text(0.5, 0, '<esc> to quit', size=12, ha="center", va="top",
+                                    transform=ax.transAxes,
+                                    bbox=dict(boxstyle="square", ec='k',fc='w'))
+                fig.canvas.draw_idle()                         
+                fig.canvas.mpl_connect('key_press_event', press)
+                plt.waitforbuttonpress()
+                # after button is pressed, remove the buttons
+                btn_skip.remove()
+                btn_keep.remove()
+                btn_esc.remove()
+                
+                # keep/skip image according to the pressed key, 'escape' to break the loop
+                if key_event.get('pressed') == 'right':
+                    skip_image = False
+                    break
+                elif key_event.get('pressed') == 'left':
+                    skip_image = True
+                    break
+                elif key_event.get('pressed') == 'escape':
+                    plt.close()
+                    raise StopIteration('User cancelled labelling images')
+                else:
+                    plt.waitforbuttonpress()
+                    
+            # if user decided to skip show the next image
+            if skip_image:
+                ax.clear()
+                continue
+            # otherwise label this image
+            else:
+                ##############################################################
+                # digitize sandy pixels
+                ##############################################################
+                ax.set_title('Click on SAND pixels (flood fill activated, tolerance = %.2f)\nwhen finished press <Enter>'%settings['tolerance'])
+                # create erase button, if you click there it delets the last selection
+                btn_erase = ax.text(im_ms.shape[1], 0, 'Erase', size=20, ha='right', va='top',
+                                    bbox=dict(boxstyle="square", ec='k',fc='w'))                
+                fig.canvas.draw_idle()
+                color_sand = settings['colors']['sand']
+                sand_pixels = []
+                while 1:
+                    seed = ginput(n=1, timeout=0, show_clicks=True)
+                    # if empty break the loop and go to next label
+                    if len(seed) == 0:
+                        break
+                    else:
+                        # round to pixel location
+                        seed = np.round(seed[0]).astype(int)     
+                    # if user clicks on erase, delete the last selection
+                    if seed[0] > 0.95*im_ms.shape[1] and seed[1] < 0.05*im_ms.shape[0]:
+                        if len(sand_pixels) > 0:
+                            im_labels[sand_pixels[-1]] = 0
+                            for k in range(im_viz.shape[2]):                              
+                                im_viz[sand_pixels[-1],k] = im_RGB[sand_pixels[-1],k]
+                            implot.set_data(im_viz)
+                            fig.canvas.draw_idle() 
+                            del sand_pixels[-1]
+                            
+                    # otherwise label the selected sand pixels
+                    else:
+                        # flood fill the NDVI and the NDWI
+                        fill_NDVI = flood(im_NDVI, (seed[1],seed[0]), tolerance=settings['tolerance'])
+                        fill_NDWI = flood(im_NDWI, (seed[1],seed[0]), tolerance=settings['tolerance'])
+                        # compute the intersection of the two masks
+                        fill_sand = np.logical_and(fill_NDVI, fill_NDWI)
+                        im_labels[fill_sand] = settings['labels']['sand'] 
+                        sand_pixels.append(fill_sand)
+                        # show the labelled pixels
+                        for k in range(im_viz.shape[2]):                              
+                            im_viz[im_labels==settings['labels']['sand'],k] = color_sand[k]
+                        implot.set_data(im_viz)
+                        fig.canvas.draw_idle() 
+                
+                ##############################################################
+                # digitize white-water pixels
+                ##############################################################
+                color_ww = settings['colors']['white-water']
+                ax.set_title('Click on individual WHITE-WATER pixels (no flood fill)\nwhen finished press <Enter>')
+                fig.canvas.draw_idle() 
+                ww_pixels = []                        
+                while 1:
+                    seed = ginput(n=1, timeout=0, show_clicks=True)
+                    # if empty break the loop and go to next label
+                    if len(seed) == 0:
+                        break
+                    else:
+                        # round to pixel location
+                        seed = np.round(seed[0]).astype(int)     
+                    # if user clicks on erase, delete the last labelled pixels
+                    if seed[0] > 0.95*im_ms.shape[1] and seed[1] < 0.05*im_ms.shape[0]:
+                        if len(ww_pixels) > 0:
+                            im_labels[ww_pixels[-1][1],ww_pixels[-1][0]] = 0
+                            for k in range(im_viz.shape[2]):
+                                im_viz[ww_pixels[-1][1],ww_pixels[-1][0],k] = im_RGB[ww_pixels[-1][1],ww_pixels[-1][0],k]
+                            implot.set_data(im_viz)
+                            fig.canvas.draw_idle()
+                            del ww_pixels[-1]
+                    else:
+                        im_labels[seed[1],seed[0]] = settings['labels']['white-water']  
+                        for k in range(im_viz.shape[2]):                              
+                            im_viz[seed[1],seed[0],k] = color_ww[k]
+                        implot.set_data(im_viz)
+                        fig.canvas.draw_idle()
+                        ww_pixels.append(seed)
+                        
+                im_sand_ww = im_viz.copy()
+                btn_erase.set(text='<Esc> to Erase', fontsize=12)
+                
+                ##############################################################
+                # digitize water pixels (with lassos)
+                ##############################################################
+                color_water = settings['colors']['water']
+                ax.set_title('Click and hold to draw lassos and select WATER pixels\nwhen finished press <Enter>')
+                fig.canvas.draw_idle() 
+                selector_water = SelectFromImage(ax, implot, color_water)
+                key_event = {}
+                while True:
+                    fig.canvas.draw_idle()                         
+                    fig.canvas.mpl_connect('key_press_event', press)
+                    plt.waitforbuttonpress()
+                    if key_event.get('pressed') == 'enter':
+                        selector_water.disconnect()
+                        break
+                    elif key_event.get('pressed') == 'escape':
+                        selector_water.array = im_sand_ww
+                        implot.set_data(selector_water.array)
+                        fig.canvas.draw_idle()                         
+                        selector_water.implot = implot
+                        selector_water.im_bool = np.zeros((selector_water.array.shape[0], selector_water.array.shape[1])) 
+                        selector_water.ind=[]          
+                # update im_viz and im_labels
+                im_viz = selector_water.array
+                selector_water.im_bool = selector_water.im_bool.astype(bool)
+                im_labels[selector_water.im_bool] = settings['labels']['water']
+                
+                im_sand_ww_water = im_viz.copy()
+                
+                ##############################################################
+                # digitize land pixels (with lassos)
+                ##############################################################
+                color_land = settings['colors']['other land features']
+                ax.set_title('Click and hold to draw lassos and select OTHER LAND pixels\nwhen finished press <Enter>')
+                fig.canvas.draw_idle() 
+                selector_land = SelectFromImage(ax, implot, color_land)
+                key_event = {}
+                while True:
+                    fig.canvas.draw_idle()                         
+                    fig.canvas.mpl_connect('key_press_event', press)
+                    plt.waitforbuttonpress()
+                    if key_event.get('pressed') == 'enter':
+                        selector_land.disconnect()
+                        break
+                    elif key_event.get('pressed') == 'escape':
+                        selector_land.array = im_sand_ww_water
+                        implot.set_data(selector_land.array)
+                        fig.canvas.draw_idle()                         
+                        selector_land.implot = implot
+                        selector_land.im_bool = np.zeros((selector_land.array.shape[0], selector_land.array.shape[1])) 
+                        selector_land.ind=[]
+                # update im_viz and im_labels
+                im_viz = selector_land.array
+                selector_land.im_bool = selector_land.im_bool.astype(bool)
+                im_labels[selector_land.im_bool] = settings['labels']['other land features']  
+                
+                # save labelled image
+                ax.set_title(filename)
+                fig.canvas.draw_idle()                         
+                fp = os.path.join(filepath_train,settings['inputs']['sitename'])
+                if not os.path.exists(fp):
+                    os.makedirs(fp)
+                fig.savefig(os.path.join(fp,filename+'.jpg'), dpi=150)
+                ax.clear()
+                # save labels and features
+                features = dict([])
+                for key in settings['labels'].keys():
+                    im_bool = im_labels == settings['labels'][key]
+                    features[key] = SDS_shoreline.calculate_features(im_ms, cloud_mask, im_bool)
+                training_data = {'labels':im_labels, 'features':features, 'label_ids':settings['labels']}
+                with open(os.path.join(fp, filename + '.pkl'), 'wb') as f:
+                    pickle.dump(training_data,f)
+                    
+    # close figure when finished
+    plt.close(fig)
+
+def load_labels(train_sites, settings):
+    """
+    Load the labelled data from the different training sites
+
+    KV WRL 2019
+
+    Arguments:
+    -----------
+    train_sites: list of str
+        sites to be loaded
+    settings: dict with the following keys
+        'labels': dict
+            list of label names (key) and label numbers (value) for each class
+        'filepath_train': str
+            directory in which to save the labelled data
+                
+    Returns:
+    -----------
+    features: dict
+        contains the features for each labelled pixel
+    
+    """    
+    
+    filepath_train = settings['filepath_train']
+    # initialize the features dict
+    features = dict([])
+    n_features = 20
+    first_row = np.nan*np.ones((1,n_features))
+    for key in settings['labels'].keys():
+        features[key] = first_row
+    # loop through each site 
+    for site in train_sites:
+        sitename = site[:site.find('.')] 
+        filepath = os.path.join(filepath_train,sitename)
+        if os.path.exists(filepath):
+            list_files = os.listdir(filepath)
+        else:
+            continue
+        # make a new list with only the .pkl files (no .jpg)
+        list_files_pkl = []
+        for file in list_files:
+            if '.pkl' in file:
+                list_files_pkl.append(file)
+        # load and append the training data to the features dict
+        for file in list_files_pkl:
+            # read file
+            with open(os.path.join(filepath, file), 'rb') as f:
+                labelled_data = pickle.load(f) 
+            for key in labelled_data['features'].keys():
+                if len(labelled_data['features'][key])>0: # check that is not empty
+                    # append rows
+                    features[key] = np.append(features[key],
+                                labelled_data['features'][key], axis=0)  
+    # remove the first row (initialized with nans) and print how many pixels
+    print('Number of pixels per class in training data:')
+    for key in features.keys(): 
+        features[key] = features[key][1:,:]
+        print('%s : %d pixels'%(key,len(features[key])))
+    
+    return features
+
+def format_training_data(features, classes, labels):
+    """
+    Format the labelled data in an X features matrix and a y labels vector, so
+    that it can be used for training an ML model.
+
+    KV WRL 2019
+
+    Arguments:
+    -----------
+    features: dict
+        contains the features for each labelled pixel
+    classes: list of str
+        names of the classes
+    labels: list of int
+        int value associated with each class (in the same order as classes)
+                
+    Returns:
+    -----------
+    X: np.array
+        matrix features along the columns and pixels along the rows
+    y: np.array
+        vector with the labels corresponding to each row of X
+    
+    """
+    
+    # initialize X and y
+    X = np.nan*np.ones((1,features[classes[0]].shape[1]))
+    y = np.nan*np.ones((1,1))
+    # append row of features to X and corresponding label to y 
+    for i,key in enumerate(classes):
+        y = np.append(y, labels[i]*np.ones((features[key].shape[0],1)), axis=0)
+        X = np.append(X, features[key], axis=0)
+    # remove first row
+    X = X[1:,:]; y = y[1:]
+    # replace nans with something close to 0
+    # training algotihms cannot handle nans
+    X[np.isnan(X)] = 1e-9 
+    
+    return X, y
+
+def plot_confusion_matrix(y_true,y_pred,classes,normalize=False,cmap=plt.cm.Blues):
+    """
+    Function copied from the scikit-learn examples (https://scikit-learn.org/stable/)
+    This function plots a confusion matrix.
+    Normalization can be applied by setting `normalize=True`.
+    
+    """
+    # compute confusion matrix
+    cm = confusion_matrix(y_true, y_pred)
+    if normalize:
+        cm = cm.astype('float') / cm.sum(axis=1)[:, np.newaxis]
+        print("Normalized confusion matrix")
+    else:
+        print('Confusion matrix, without normalization')
+        
+    # plot confusion matrix
+    fig, ax = plt.subplots(figsize=(6,6), tight_layout=True)
+    im = ax.imshow(cm, interpolation='nearest', cmap=cmap)
+#    ax.figure.colorbar(im, ax=ax)
+    ax.set(xticks=np.arange(cm.shape[1]),
+           yticks=np.arange(cm.shape[0]), ylim=[3.5,-0.5],
+           xticklabels=classes, yticklabels=classes,
+           ylabel='True label',
+           xlabel='Predicted label')
+
+    # rotate the tick labels and set their alignment.
+    plt.setp(ax.get_xticklabels(), rotation=45, ha="right",
+             rotation_mode="anchor")
+
+    # loop over data dimensions and create text annotations.
+    fmt = '.2f' if normalize else 'd'
+    thresh = cm.max() / 2.
+    for i in range(cm.shape[0]):
+        for j in range(cm.shape[1]):
+            ax.text(j, i, format(cm[i, j], fmt),
+                    ha="center", va="center",
+                    color="white" if cm[i, j] > thresh else "black",
+                    fontsize=12)
+    fig.tight_layout()
+    return ax
+
+def evaluate_classifier(classifier, metadata, settings):
+    """
+    Apply the image classifier to all the images and save the classified images.
+
+    KV WRL 2019
+
+    Arguments:
+    -----------
+    classifier: joblib object
+        classifier model to be used for image classification
+    metadata: dict
+        contains all the information about the satellite images that were downloaded
+    settings: dict with the following keys
+        'inputs': dict
+            input parameters (sitename, filepath, polygon, dates, sat_list)
+        'cloud_thresh': float
+            value between 0 and 1 indicating the maximum cloud fraction in 
+            the cropped image that is accepted
+        'cloud_mask_issue': boolean
+            True if there is an issue with the cloud mask and sand pixels
+            are erroneously being masked on the images
+        'output_epsg': int
+            output spatial reference system as EPSG code
+        'buffer_size': int
+            size of the buffer (m) around the sandy pixels over which the pixels 
+            are considered in the thresholding algorithm
+        'min_beach_area': int
+            minimum allowable object area (in metres^2) for the class 'sand',
+            the area is converted to number of connected pixels
+        'min_length_sl': int
+            minimum length (in metres) of shoreline contour to be valid
+
+    Returns:
+    -----------
+    Saves .jpg images with the output of the classification in the folder ./detection
+    
+    """  
+    
+    # create folder called evaluation
+    fp = os.path.join(os.getcwd(), 'evaluation')
+    if not os.path.exists(fp):
+        os.makedirs(fp)
+        
+    # initialize figure (not interactive)
+    plt.ioff()
+    fig,ax = plt.subplots(1,2,figsize=[17,10],sharex=True, sharey=True,
+                          constrained_layout=True)
+
+    # create colormap for labels
+    cmap = cm.get_cmap('tab20c')
+    colorpalette = cmap(np.arange(0,13,1))
+    colours = np.zeros((3,4))
+    colours[0,:] = colorpalette[5]
+    colours[1,:] = np.array([204/255,1,1,1])
+    colours[2,:] = np.array([0,91/255,1,1])
+    # loop through satellites
+    for satname in metadata.keys():
+        filepath = SDS_tools.get_filepath(settings['inputs'],satname)
+        filenames = metadata[satname]['filenames']
+        
+        # load classifiers and
+        if satname in ['L5','L7','L8']:
+            pixel_size = 15
+        elif satname == 'S2':
+            pixel_size = 10
+        # convert settings['min_beach_area'] and settings['buffer_size'] from metres to pixels
+        buffer_size_pixels = np.ceil(settings['buffer_size']/pixel_size)
+        min_beach_area_pixels = np.ceil(settings['min_beach_area']/pixel_size**2)
+        
+        # loop through images
+        for i in range(len(filenames)):   
+            # image filename
+            fn = SDS_tools.get_filenames(filenames[i],filepath, satname)
+            # read and preprocess image
+            im_ms, georef, cloud_mask, im_extra, im_QA, im_nodata = SDS_preprocess.preprocess_single(fn, satname, settings['cloud_mask_issue'])
+            image_epsg = metadata[satname]['epsg'][i]
+
+            # compute cloud_cover percentage (with no data pixels)
+            cloud_cover_combined = np.divide(sum(sum(cloud_mask.astype(int))),
+                                    (cloud_mask.shape[0]*cloud_mask.shape[1]))
+            if cloud_cover_combined > 0.99: # if 99% of cloudy pixels in image skip
+                continue
+
+            # remove no data pixels from the cloud mask (for example L7 bands of no data should not be accounted for)
+            cloud_mask_adv = np.logical_xor(cloud_mask, im_nodata)
+            # compute updated cloud cover percentage (without no data pixels)
+            cloud_cover = np.divide(sum(sum(cloud_mask_adv.astype(int))),
+                                    (sum(sum((~im_nodata).astype(int)))))
+            # skip image if cloud cover is above threshold
+            if cloud_cover > settings['cloud_thresh']:
+                continue
+            # calculate a buffer around the reference shoreline (if any has been digitised)
+            im_ref_buffer = SDS_shoreline.create_shoreline_buffer(cloud_mask.shape, georef, image_epsg,
+                                                    pixel_size, settings)
+            # classify image in 4 classes (sand, whitewater, water, other) with NN classifier
+            im_classif, im_labels = SDS_shoreline.classify_image_NN(im_ms, im_extra, cloud_mask,
+                                    min_beach_area_pixels, classifier)
+            # there are two options to map the contours:
+            # if there are pixels in the 'sand' class --> use find_wl_contours2 (enhanced)
+            # otherwise use find_wl_contours2 (traditional)
+            try: # use try/except structure for long runs
+                if sum(sum(im_labels[:,:,0])) < 10 :
+                    # compute MNDWI image (SWIR-G)
+                    im_mndwi = SDS_tools.nd_index(im_ms[:,:,4], im_ms[:,:,1], cloud_mask)
+                    # find water contours on MNDWI grayscale image
+                    contours_mwi, t_mndwi = SDS_shoreline.find_wl_contours1(im_mndwi, cloud_mask, im_ref_buffer)
+                else:
+                    # use classification to refine threshold and extract the sand/water interface
+                    contours_mwi, t_mndwi = SDS_shoreline.find_wl_contours2(im_ms, im_labels,
+                                                cloud_mask, buffer_size_pixels, im_ref_buffer)
+            except:
+                print('Could not map shoreline for this image: ' + filenames[i])
+                continue
+            # process the water contours into a shoreline
+            shoreline = SDS_shoreline.process_shoreline(contours_mwi, cloud_mask, georef, image_epsg, settings)
+            try:
+                sl_pix = SDS_tools.convert_world2pix(SDS_tools.convert_epsg(shoreline,
+                                                                            settings['output_epsg'],
+                                                                            image_epsg)[:,[0,1]], georef)
+            except:
+                # if try fails, just add nan into the shoreline vector so the next parts can still run
+                sl_pix = np.array([[np.nan, np.nan],[np.nan, np.nan]])
+            # make a plot
+            im_RGB = SDS_preprocess.rescale_image_intensity(im_ms[:,:,[2,1,0]], cloud_mask, 99.9)
+            # create classified image
+            im_class = np.copy(im_RGB)
+            for k in range(0,im_labels.shape[2]):
+                im_class[im_labels[:,:,k],0] = colours[k,0]
+                im_class[im_labels[:,:,k],1] = colours[k,1]
+                im_class[im_labels[:,:,k],2] = colours[k,2]        
+            # show images
+            ax[0].imshow(im_RGB)
+            ax[1].imshow(im_RGB)
+            ax[1].imshow(im_class, alpha=0.5)
+            ax[0].axis('off')
+            ax[1].axis('off')
+            filename = filenames[i][:filenames[i].find('.')][:-4] 
+            ax[0].set_title(filename)  
+            ax[0].plot(sl_pix[:,0], sl_pix[:,1], 'k.', markersize=3)
+            ax[1].plot(sl_pix[:,0], sl_pix[:,1], 'k.', markersize=3)
+            # save figure
+            fig.savefig(os.path.join(fp,settings['inputs']['sitename'] + filename[:19] +'.jpg'), dpi=150)
+            # clear axes
+            for cax in fig.axes:
+               cax.clear()
+   
+    # close the figure at the end
+    plt.close()

--- a/notebooks/coastsat/SDS_download.py
+++ b/notebooks/coastsat/SDS_download.py
@@ -1,0 +1,965 @@
+"""
+This module contains all the functions needed to download the satellite images
+from the Google Earth Engine server
+
+Author: Kilian Vos, Water Research Laboratory, University of New South Wales
+"""
+
+# load basic modules
+import os
+import numpy as np
+import matplotlib.pyplot as plt
+import pdb
+
+# earth engine module
+import ee
+
+# modules to download, unzip and stack the images
+from urllib.request import urlretrieve
+import zipfile
+import copy
+import shutil
+from osgeo import gdal
+
+# additional modules
+from datetime import datetime, timedelta
+import pytz
+import pickle
+from skimage import morphology, transform
+from scipy import ndimage
+
+# CoastSat modules
+from coastsat import SDS_preprocess, SDS_tools, gdal_merge
+
+np.seterr(all='ignore') # raise/ignore divisions by 0 and nans
+
+# Main function to download images from the EarthEngine server
+def retrieve_images(inputs):
+    """
+    Downloads all images from Landsat 5, Landsat 7, Landsat 8 and Sentinel-2
+    covering the area of interest and acquired between the specified dates.
+    The downloaded images are in .TIF format and organised in subfolders, divided
+    by satellite mission. The bands are also subdivided by pixel resolution.
+
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    inputs: dict with the following keys
+        'sitename': str
+            name of the site
+        'polygon': list
+            polygon containing the lon/lat coordinates to be extracted,
+            longitudes in the first column and latitudes in the second column,
+            there are 5 pairs of lat/lon with the fifth point equal to the first point:
+            ```
+            polygon = [[[151.3, -33.7],[151.4, -33.7],[151.4, -33.8],[151.3, -33.8],
+            [151.3, -33.7]]]
+            ```
+        'dates': list of str
+            list that contains 2 strings with the initial and final dates in
+            format 'yyyy-mm-dd':
+            ```
+            dates = ['1987-01-01', '2018-01-01']
+            ```
+        'sat_list': list of str
+            list that contains the names of the satellite missions to include:
+            ```
+            sat_list = ['L5', 'L7', 'L8', 'S2']
+            ```
+        'filepath_data': str
+            filepath to the directory where the images are downloaded
+
+    Returns:
+    -----------
+    metadata: dict
+        contains the information about the satellite images that were downloaded:
+        date, filename, georeferencing accuracy and image coordinate reference system
+
+    """
+    
+    # initialise connection with GEE server
+    ee.Initialize()
+
+    # check image availabiliy and retrieve list of images
+    im_dict_T1, im_dict_T2 = check_images_available(inputs)
+
+    # if user also wants to download T2 images, merge both lists
+    if 'include_T2' in inputs.keys():
+        for key in inputs['sat_list']:
+            if key == 'S2': continue
+            else: im_dict_T1[key] += im_dict_T2[key]
+
+    # remove UTM duplicates in S2 collections (they provide several projections for same images)
+    if 'S2' in inputs['sat_list'] and len(im_dict_T1['S2'])>0:
+        im_dict_T1['S2'] = filter_S2_collection(im_dict_T1['S2'])
+
+    # create a new directory for this site with the name of the site
+    im_folder = os.path.join(inputs['filepath'],inputs['sitename'])
+    if not os.path.exists(im_folder): os.makedirs(im_folder)
+
+    print('\nDownloading images:')
+    suffix = '.tif'
+    for satname in im_dict_T1.keys():
+        print('%s: %d images'%(satname,len(im_dict_T1[satname])))
+        # create subfolder structure to store the different bands
+        filepaths = create_folder_structure(im_folder, satname)
+        # initialise variables and loop through images
+        georef_accs = []; filenames = []; all_names = []; im_epsg = []
+        for i in range(len(im_dict_T1[satname])):
+
+            im_meta = im_dict_T1[satname][i]
+
+            # get time of acquisition (UNIX time) and convert to datetime
+            t = im_meta['properties']['system:time_start']
+            im_timestamp = datetime.fromtimestamp(t/1000, tz=pytz.utc)
+            im_date = im_timestamp.strftime('%Y-%m-%d-%H-%M-%S')
+
+            # get epsg code
+            im_epsg.append(int(im_meta['bands'][0]['crs'][5:]))
+
+            # get geometric accuracy
+            if satname in ['L5','L7','L8']:
+                if 'GEOMETRIC_RMSE_MODEL' in im_meta['properties'].keys():
+                    acc_georef = im_meta['properties']['GEOMETRIC_RMSE_MODEL']
+                else:
+                    acc_georef = 12 # default value of accuracy (RMSE = 12m)
+            elif satname in ['S2']:
+                # Sentinel-2 products don't provide a georeferencing accuracy (RMSE as in Landsat)
+                # but they have a flag indicating if the geometric quality control was passed or failed
+                # if passed a value of 1 is stored if failed a value of -1 is stored in the metadata
+                # the name of the property containing the flag changes across the S2 archive
+                # check which flag name is used for the image and store the 1/-1 for acc_georef
+                flag_names = ['GEOMETRIC_QUALITY_FLAG', 'GEOMETRIC_QUALITY', 'quality_check', 'GENERAL_QUALITY_FLAG']
+                for key in flag_names: 
+                    if key in im_meta['properties'].keys(): break
+                if im_meta['properties'][key] == 'PASSED': acc_georef = 1
+                else: acc_georef = -1
+            georef_accs.append(acc_georef)
+
+            bands = dict([])
+            im_fn = dict([])
+            # first delete dimensions key from dictionnary
+            # otherwise the entire image is extracted (don't know why)
+            im_bands = im_meta['bands']
+            for j in range(len(im_bands)): del im_bands[j]['dimensions']
+
+            # Landsat 5 download
+            if satname == 'L5':
+                bands[''] = [im_bands[0], im_bands[1], im_bands[2], im_bands[3],
+                             im_bands[4], im_bands[7]]
+                im_fn[''] = im_date + '_' + satname + '_' + inputs['sitename'] + suffix
+                # if two images taken at the same date add 'dup' to the name (duplicate)
+                if any(im_fn[''] in _ for _ in all_names):
+                    im_fn[''] = im_date + '_' + satname + '_' + inputs['sitename'] + '_dup' + suffix
+                all_names.append(im_fn[''])
+                filenames.append(im_fn[''])
+                # download .tif from EE
+                while True:
+                    try:
+                        im_ee = ee.Image(im_meta['id'])
+                        local_data = download_tif(im_ee, inputs['polygon'], bands[''], filepaths[1])
+                        break
+                    except:
+                        continue
+                # rename the file as the image is downloaded as 'data.tif'
+                try:
+                    os.rename(local_data, os.path.join(filepaths[1], im_fn['']))
+                except: # overwrite if already exists
+                    os.remove(os.path.join(filepaths[1], im_fn['']))
+                    os.rename(local_data, os.path.join(filepaths[1], im_fn['']))
+                # metadata for .txt file
+                filename_txt = im_fn[''].replace('.tif','')
+                metadict = {'filename':im_fn[''],'acc_georef':georef_accs[i],
+                            'epsg':im_epsg[i]}
+
+            # Landsat 7 and 8 download
+            elif satname in ['L7', 'L8']:
+                if satname == 'L7':
+                    bands['pan'] = [im_bands[8]] # panchromatic band
+                    bands['ms'] = [im_bands[0], im_bands[1], im_bands[2], im_bands[3],
+                                   im_bands[4], im_bands[9]] # multispectral bands
+                else:
+                    bands['pan'] = [im_bands[7]] # panchromatic band
+                    bands['ms'] = [im_bands[1], im_bands[2], im_bands[3], im_bands[4],
+                                   im_bands[5], im_bands[11]] # multispectral bands
+                for key in bands.keys():
+                    im_fn[key] = im_date + '_' + satname + '_' + inputs['sitename'] + '_' + key + suffix
+                # if two images taken at the same date add 'dup' to the name (duplicate)
+                if any(im_fn['pan'] in _ for _ in all_names):
+                    for key in bands.keys():
+                        im_fn[key] = im_date + '_' + satname + '_' + inputs['sitename'] + '_' + key + '_dup' + suffix
+                all_names.append(im_fn['pan'])
+                filenames.append(im_fn['pan'])
+                # download .tif from EE (panchromatic band and multispectral bands)
+                while True:
+                    try:
+                        im_ee = ee.Image(im_meta['id'])
+                        local_data_pan = download_tif(im_ee, inputs['polygon'], bands['pan'], filepaths[1])
+                        local_data_ms = download_tif(im_ee, inputs['polygon'], bands['ms'], filepaths[2])
+                        break
+                    except:
+                        continue
+                # rename the files as the image is downloaded as 'data.tif'
+                try: # panchromatic
+                    os.rename(local_data_pan, os.path.join(filepaths[1], im_fn['pan']))
+                except: # overwrite if already exists
+                    os.remove(os.path.join(filepaths[1], im_fn['pan']))
+                    os.rename(local_data_pan, os.path.join(filepaths[1], im_fn['pan']))
+                try: # multispectral
+                    os.rename(local_data_ms, os.path.join(filepaths[2], im_fn['ms']))
+                except: # overwrite if already exists
+                    os.remove(os.path.join(filepaths[2], im_fn['ms']))
+                    os.rename(local_data_ms, os.path.join(filepaths[2], im_fn['ms']))
+                # metadata for .txt file
+                filename_txt = im_fn['pan'].replace('_pan','').replace('.tif','')
+                metadict = {'filename':im_fn['pan'],'acc_georef':georef_accs[i],
+                            'epsg':im_epsg[i]}
+
+            # Sentinel-2 download
+            elif satname in ['S2']:
+                bands['10m'] = [im_bands[1], im_bands[2], im_bands[3], im_bands[7]] # multispectral bands
+                bands['20m'] = [im_bands[11]] # SWIR band
+                bands['60m'] = [im_bands[15]] # QA band
+                for key in bands.keys():
+                    im_fn[key] = im_date + '_' + satname + '_' + inputs['sitename'] + '_' + key + suffix
+                # if two images taken at the same date add 'dup' to the name (duplicate)
+                if any(im_fn['10m'] in _ for _ in all_names):
+                    for key in bands.keys():
+                        im_fn[key] = im_date + '_' + satname + '_' + inputs['sitename'] + '_' + key + '_dup2' + suffix
+                    # also check for triplicates (only on S2 imagery) and add 'tri' to the name
+                    if im_fn['10m'] in all_names:
+                        for key in bands.keys():
+                            im_fn[key] = im_date + '_' + satname + '_' + inputs['sitename'] + '_' + key + '_dup3' + suffix
+                        # also check for quadruplicates (only on S2 imagery) add 'qua' to the name
+                        if im_fn['10m'] in all_names:
+                            for key in bands.keys():
+                                im_fn[key] = im_date + '_' + satname + '_' + inputs['sitename'] + '_' + key + '_dup4' + suffix
+                all_names.append(im_fn['10m'])
+                filenames.append(im_fn['10m'])
+                # download .tif from EE (multispectral bands at 3 different resolutions)
+                while True:
+                    try:
+                        im_ee = ee.Image(im_meta['id'])
+                        local_data_10m = download_tif(im_ee, inputs['polygon'], bands['10m'], filepaths[1])
+                        local_data_20m = download_tif(im_ee, inputs['polygon'], bands['20m'], filepaths[2])
+                        local_data_60m = download_tif(im_ee, inputs['polygon'], bands['60m'], filepaths[3])
+                        break
+                    except:
+                        continue
+                # rename the files as the image is downloaded as 'data.tif'
+                try: # 10m
+                    os.rename(local_data_10m, os.path.join(filepaths[1], im_fn['10m']))
+                except: # overwrite if already exists
+                    os.remove(os.path.join(filepaths[1], im_fn['10m']))
+                    os.rename(local_data_10m, os.path.join(filepaths[1], im_fn['10m']))
+                try: # 20m
+                    os.rename(local_data_20m, os.path.join(filepaths[2], im_fn['20m']))
+                except: # overwrite if already exists
+                    os.remove(os.path.join(filepaths[2], im_fn['20m']))
+                    os.rename(local_data_20m, os.path.join(filepaths[2], im_fn['20m']))
+                try: # 60m
+                    os.rename(local_data_60m, os.path.join(filepaths[3], im_fn['60m']))
+                except: # overwrite if already exists
+                    os.remove(os.path.join(filepaths[3], im_fn['60m']))
+                    os.rename(local_data_60m, os.path.join(filepaths[3], im_fn['60m']))
+                # metadata for .txt file
+                filename_txt = im_fn['10m'].replace('_10m','').replace('.tif','')
+                metadict = {'filename':im_fn['10m'],'acc_georef':georef_accs[i],
+                            'epsg':im_epsg[i]}
+
+            # write metadata
+            with open(os.path.join(filepaths[0],filename_txt + '.txt'), 'w') as f:
+                for key in metadict.keys():
+                    f.write('%s\t%s\n'%(key,metadict[key]))
+            # print percentage completion for user
+            print('\r%d%%' %int((i+1)/len(im_dict_T1[satname])*100), end='')
+
+        print('')
+
+    # once all images have been downloaded, load metadata from .txt files
+    metadata = get_metadata(inputs)
+
+    # merge overlapping images (necessary only if the polygon is at the boundary of an image)
+    if 'S2' in metadata.keys():
+        try:
+            metadata = merge_overlapping_images(metadata,inputs)
+        except:
+            print('WARNING: there was an error while merging overlapping S2 images,'+
+                  ' please open an issue on Github at https://github.com/kvos/CoastSat/issues'+
+                  ' and include your script so we can find out what happened.')
+
+    # save metadata dict
+    with open(os.path.join(im_folder, inputs['sitename'] + '_metadata' + '.pkl'), 'wb') as f:
+        pickle.dump(metadata, f)
+
+    return metadata
+
+# function to load the metadata if images have already been downloaded
+def get_metadata(inputs):
+    """
+    Gets the metadata from the downloaded images by parsing .txt files located
+    in the \meta subfolder.
+
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    inputs: dict with the following fields
+        'sitename': str
+            name of the site
+        'filepath_data': str
+            filepath to the directory where the images are downloaded
+
+    Returns:
+    -----------
+    metadata: dict
+        contains the information about the satellite images that were downloaded:
+        date, filename, georeferencing accuracy and image coordinate reference system
+
+    """
+    # directory containing the images
+    filepath = os.path.join(inputs['filepath'],inputs['sitename'])
+    # initialize metadata dict
+    metadata = dict([])
+    # loop through the satellite missions
+    for satname in ['L5','L7','L8','S2']:
+        # if a folder has been created for the given satellite mission
+        if satname in os.listdir(filepath):
+            # update the metadata dict
+            metadata[satname] = {'filenames':[], 'acc_georef':[], 'epsg':[], 'dates':[]}
+            # directory where the metadata .txt files are stored
+            filepath_meta = os.path.join(filepath, satname, 'meta')
+            # get the list of filenames and sort it chronologically
+            filenames_meta = os.listdir(filepath_meta)
+            filenames_meta.sort()
+            # loop through the .txt files
+            for im_meta in filenames_meta:
+                # read them and extract the metadata info: filename, georeferencing accuracy
+                # epsg code and date
+                with open(os.path.join(filepath_meta, im_meta), 'r') as f:
+                    filename = f.readline().split('\t')[1].replace('\n','')
+                    acc_georef = float(f.readline().split('\t')[1].replace('\n',''))
+                    epsg = int(f.readline().split('\t')[1].replace('\n',''))
+                date_str = filename[0:19]
+                date = pytz.utc.localize(datetime(int(date_str[:4]),int(date_str[5:7]),
+                                                  int(date_str[8:10]),int(date_str[11:13]),
+                                                  int(date_str[14:16]),int(date_str[17:19])))
+                # store the information in the metadata dict
+                metadata[satname]['filenames'].append(filename)
+                metadata[satname]['acc_georef'].append(acc_georef)
+                metadata[satname]['epsg'].append(epsg)
+                metadata[satname]['dates'].append(date)
+
+    # save a .pkl file containing the metadata dict
+    with open(os.path.join(filepath, inputs['sitename'] + '_metadata' + '.pkl'), 'wb') as f:
+        pickle.dump(metadata, f)
+
+    return metadata
+###################################################################################################
+# AUXILIARY FUNCTIONS
+###################################################################################################
+
+def check_images_available(inputs):
+    """
+    Create the structure of subfolders for each satellite mission
+
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    inputs: dict
+        inputs dictionnary
+
+    Returns:
+    -----------
+    im_dict_T1: list of dict
+        list of images in Tier 1 and Level-1C
+    im_dict_T2: list of dict
+        list of images in Tier 2 (Landsat only)
+    """
+
+    # check if dates are in correct order
+    dates = [datetime.strptime(_,'%Y-%m-%d') for _ in inputs['dates']]
+    if  dates[1] <= dates[0]:
+        raise Exception('Verify that your dates are in the correct order')
+
+    # check if EE was initialised or not
+    try:
+        ee.ImageCollection('LANDSAT/LT05/C01/T1_TOA')
+    except:
+        ee.Initialize()
+
+    print('Images available between %s and %s:'%(inputs['dates'][0],inputs['dates'][1]), end='\n')
+    # check how many images are available in Tier 1 and Sentinel Level-1C
+    col_names_T1 = {'L5':'LANDSAT/LT05/C01/T1_TOA',
+                 'L7':'LANDSAT/LE07/C01/T1_TOA',
+                 'L8':'LANDSAT/LC08/C01/T1_TOA',
+                 'S2':'COPERNICUS/S2'}
+
+    print('- In Landsat Tier 1 & Sentinel-2 Level-1C:')
+    im_dict_T1 = dict([])
+    sum_img = 0
+    for satname in inputs['sat_list']:
+
+        # get list of images in EE collection
+        while True:
+            try:
+                ee_col = ee.ImageCollection(col_names_T1[satname])
+                col = ee_col.filterBounds(ee.Geometry.Polygon(inputs['polygon']))\
+                            .filterDate(inputs['dates'][0],inputs['dates'][1])
+                im_list = col.getInfo().get('features')
+                break
+            except:
+                continue
+        # remove very cloudy images (>95% cloud cover)
+        im_list_upt = remove_cloudy_images(im_list, satname)
+        sum_img = sum_img + len(im_list_upt)
+        print('  %s: %d images'%(satname,len(im_list_upt)))
+        im_dict_T1[satname] = im_list_upt
+
+    print('  Total: %d images'%sum_img)
+
+    # in only S2 is in sat_list, stop here
+    if len(inputs['sat_list']) == 1 and inputs['sat_list'][0] == 'S2':
+        return im_dict_T1, []
+
+    # otherwise check how many images are available in Landsat Tier 2
+    col_names_T2 = {'L5':'LANDSAT/LT05/C01/T2_TOA',
+                 'L7':'LANDSAT/LE07/C01/T2_TOA',
+                 'L8':'LANDSAT/LC08/C01/T2_TOA'}
+    print('- In Landsat Tier 2:', end='\n')
+    im_dict_T2 = dict([])
+    sum_img = 0
+    for satname in inputs['sat_list']:
+        if satname == 'S2': continue
+        # get list of images in EE collection
+        while True:
+            try:
+                ee_col = ee.ImageCollection(col_names_T2[satname])
+                col = ee_col.filterBounds(ee.Geometry.Polygon(inputs['polygon']))\
+                            .filterDate(inputs['dates'][0],inputs['dates'][1])
+                im_list = col.getInfo().get('features')
+                break
+            except:
+                continue
+        # remove very cloudy images (>95% cloud cover)
+        im_list_upt = remove_cloudy_images(im_list, satname)
+        sum_img = sum_img + len(im_list_upt)
+        print('  %s: %d images'%(satname,len(im_list_upt)))
+        im_dict_T2[satname] = im_list_upt
+
+    print('  Total: %d images'%sum_img)
+
+    return im_dict_T1, im_dict_T2
+
+
+def download_tif(image, polygon, bandsId, filepath):
+    """
+    Downloads a .TIF image from the ee server. The image is downloaded as a
+    zip file then moved to the working directory, unzipped and stacked into a
+    single .TIF file.
+
+    Two different codes based on which version of the earth-engine-api is being
+    used.
+
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    image: ee.Image
+        Image object to be downloaded
+    polygon: list
+        polygon containing the lon/lat coordinates to be extracted
+        longitudes in the first column and latitudes in the second column
+    bandsId: list of dict
+        list of bands to be downloaded
+    filepath: location where the temporary file should be saved
+
+    Returns:
+    -----------
+    Downloads an image in a file named data.tif
+
+    """
+
+    # for the old version of ee only
+    if int(ee.__version__[-3:]) <= 201:
+        url = ee.data.makeDownloadUrl(ee.data.getDownloadId({
+            'image': image.serialize(),
+            'region': polygon,
+            'bands': bandsId,
+            'filePerBand': 'false',
+            'name': 'data',
+            }))
+        local_zip, headers = urlretrieve(url)
+        with zipfile.ZipFile(local_zip) as local_zipfile:
+            return local_zipfile.extract('data.tif', filepath)
+    # for the newer versions of ee
+    else:
+        # crop image on the server and create url to download
+        url = ee.data.makeDownloadUrl(ee.data.getDownloadId({
+            'image': image,
+            'region': polygon,
+            'bands': bandsId,
+            'filePerBand': 'false',
+            'name': 'data',
+            }))
+        # download zipfile with the cropped bands
+        local_zip, headers = urlretrieve(url)
+        # move zipfile from temp folder to data folder
+        dest_file = os.path.join(filepath, 'imagezip')
+        shutil.move(local_zip,dest_file)
+        # unzip file
+        with zipfile.ZipFile(dest_file) as local_zipfile:
+            for fn in local_zipfile.namelist():
+                local_zipfile.extract(fn, filepath)
+            # filepath + filename to single bands
+            fn_tifs = [os.path.join(filepath,_) for _ in local_zipfile.namelist()]
+        # stack bands into single .tif
+        outds = gdal.BuildVRT(os.path.join(filepath,'stacked.vrt'), fn_tifs, separate=True)
+        outds = gdal.Translate(os.path.join(filepath,'data.tif'), outds)
+        # delete single-band files
+        for fn in fn_tifs: os.remove(fn)
+        # delete .vrt file
+        os.remove(os.path.join(filepath,'stacked.vrt'))
+        # delete zipfile
+        os.remove(dest_file)
+        # delete data.tif.aux (not sure why this is created)
+        if os.path.exists(os.path.join(filepath,'data.tif.aux')):
+            os.remove(os.path.join(filepath,'data.tif.aux'))
+        # return filepath to stacked file called data.tif
+        return os.path.join(filepath,'data.tif')
+
+
+def create_folder_structure(im_folder, satname):
+    """
+    Create the structure of subfolders for each satellite mission
+
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    im_folder: str
+        folder where the images are to be downloaded
+    satname:
+        name of the satellite mission
+
+    Returns:
+    -----------
+    filepaths: list of str
+        filepaths of the folders that were created
+    """
+
+    # one folder for the metadata (common to all satellites)
+    filepaths = [os.path.join(im_folder, satname, 'meta')]
+    # subfolders depending on satellite mission
+    if satname == 'L5':
+        filepaths.append(os.path.join(im_folder, satname, '30m'))
+    elif satname in ['L7','L8']:
+        filepaths.append(os.path.join(im_folder, satname, 'pan'))
+        filepaths.append(os.path.join(im_folder, satname, 'ms'))
+    elif satname in ['S2']:
+        filepaths.append(os.path.join(im_folder, satname, '10m'))
+        filepaths.append(os.path.join(im_folder, satname, '20m'))
+        filepaths.append(os.path.join(im_folder, satname, '60m'))
+    # create the subfolders if they don't exist already
+    for fp in filepaths:
+        if not os.path.exists(fp): os.makedirs(fp)
+
+    return filepaths
+
+
+def remove_cloudy_images(im_list, satname, prc_cloud_cover=95):
+    """
+    Removes from the EE collection very cloudy images (>95% cloud cover)
+
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    im_list: list
+        list of images in the collection
+    satname:
+        name of the satellite mission
+    prc_cloud_cover: int
+        percentage of cloud cover acceptable on the images
+
+    Returns:
+    -----------
+    im_list_upt: list
+        updated list of images
+    """
+
+    # remove very cloudy images from the collection (>95% cloud)
+    if satname in ['L5','L7','L8']:
+        cloud_property = 'CLOUD_COVER'
+    elif satname in ['S2']:
+        cloud_property = 'CLOUDY_PIXEL_PERCENTAGE'
+    cloud_cover = [_['properties'][cloud_property] for _ in im_list]
+    if np.any([_ > prc_cloud_cover for _ in cloud_cover]):
+        idx_delete = np.where([_ > prc_cloud_cover for _ in cloud_cover])[0]
+        im_list_upt = [x for k,x in enumerate(im_list) if k not in idx_delete]
+    else:
+        im_list_upt = im_list
+
+    return im_list_upt
+
+
+def filter_S2_collection(im_list):
+    """
+    Removes duplicates from the EE collection of Sentinel-2 images (many duplicates)
+    Finds the images that were acquired at the same time but have different utm zones.
+
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    im_list: list
+        list of images in the collection
+
+    Returns:
+    -----------
+    im_list_flt: list
+        filtered list of images
+    """
+
+    # get datetimes
+    timestamps = [datetime.fromtimestamp(_['properties']['system:time_start']/1000,
+                                         tz=pytz.utc) for _ in im_list]
+    # get utm zone projections
+    utm_zones = np.array([int(_['bands'][0]['crs'][5:]) for _ in im_list])
+    if len(np.unique(utm_zones)) == 1:
+        return im_list
+    else:
+        utm_zone_selected =  np.max(np.unique(utm_zones))
+        # find the images that were acquired at the same time but have different utm zones
+        idx_all = np.arange(0,len(im_list),1)
+        idx_covered = np.ones(len(im_list)).astype(bool)
+        idx_delete = []
+        i = 0
+        while 1:
+            same_time = np.abs([(timestamps[i]-_).total_seconds() for _ in timestamps]) < 60*60*24
+            idx_same_time = np.where(same_time)[0]
+            same_utm = utm_zones == utm_zone_selected
+            # get indices that have the same time (less than 24h apart) but not the same utm zone
+            idx_temp = np.where([same_time[j] == True and same_utm[j] == False for j in idx_all])[0]
+            idx_keep = idx_same_time[[_ not in idx_temp for _ in idx_same_time]]
+            # if more than 2 images with same date and same utm, drop the last ones
+            if len(idx_keep) > 2:
+               idx_temp = np.append(idx_temp,idx_keep[-(len(idx_keep)-2):])
+            for j in idx_temp:
+                idx_delete.append(j)
+            idx_covered[idx_same_time] = False
+            if np.any(idx_covered):
+                i = np.where(idx_covered)[0][0]
+            else:
+                break
+        # update the collection by deleting all those images that have same timestamp
+        # and different utm projection
+        im_list_flt = [x for k,x in enumerate(im_list) if k not in idx_delete]
+
+    return im_list_flt
+
+
+def merge_overlapping_images(metadata,inputs):
+    """
+    Merge simultaneous overlapping images that cover the area of interest.
+    When the area of interest is located at the boundary between 2 images, there
+    will be overlap between the 2 images and both will be downloaded from Google
+    Earth Engine. This function merges the 2 images, so that the area of interest
+    is covered by only 1 image.
+
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    metadata: dict
+        contains all the information about the satellite images that were downloaded
+    inputs: dict with the following keys
+        'sitename': str
+            name of the site
+        'polygon': list
+            polygon containing the lon/lat coordinates to be extracted,
+            longitudes in the first column and latitudes in the second column,
+            there are 5 pairs of lat/lon with the fifth point equal to the first point:
+            ```
+            polygon = [[[151.3, -33.7],[151.4, -33.7],[151.4, -33.8],[151.3, -33.8],
+            [151.3, -33.7]]]
+            ```
+        'dates': list of str
+            list that contains 2 strings with the initial and final dates in
+            format 'yyyy-mm-dd':
+            ```
+            dates = ['1987-01-01', '2018-01-01']
+            ```
+        'sat_list': list of str
+            list that contains the names of the satellite missions to include:
+            ```
+            sat_list = ['L5', 'L7', 'L8', 'S2']
+            ```
+        'filepath_data': str
+            filepath to the directory where the images are downloaded
+
+    Returns:
+    -----------
+    metadata_updated: dict
+        updated metadata
+
+    """
+
+    # only for Sentinel-2 at this stage (not sure if this is needed for Landsat images)
+    sat = 'S2'
+    filepath = os.path.join(inputs['filepath'], inputs['sitename'])
+    filenames = metadata[sat]['filenames']
+    total_images = len(filenames)
+    # nested function
+    def duplicates_dict(lst):
+        "return duplicates and indices"
+        def duplicates(lst, item):
+                return [i for i, x in enumerate(lst) if x == item]
+        return dict((x, duplicates(lst, x)) for x in set(lst) if lst.count(x) > 1)    
+      
+    # first pass on images that have the exact same timestamp
+    duplicates = duplicates_dict([_.split('_')[0] for _ in filenames])
+    total_removed_step1 = 0
+    if len(duplicates) > 0:
+        # loop through each pair of duplicates and merge them
+        for key in duplicates.keys():
+            idx_dup = duplicates[key]
+            # get full filenames (3 images and .txtt) for each index and bounding polygons
+            fn_im, polygons, im_epsg = [], [], []
+            for index in range(len(idx_dup)):
+                # image names
+                fn_im.append([os.path.join(filepath, 'S2', '10m', filenames[idx_dup[index]]),
+                      os.path.join(filepath, 'S2', '20m',  filenames[idx_dup[index]].replace('10m','20m')),
+                      os.path.join(filepath, 'S2', '60m',  filenames[idx_dup[index]].replace('10m','60m')),
+                      os.path.join(filepath, 'S2', 'meta', filenames[idx_dup[index]].replace('_10m','').replace('.tif','.txt'))])
+                # bounding polygons
+                polygons.append(SDS_tools.get_image_bounds(fn_im[index][0]))
+                im_epsg.append(metadata[sat]['epsg'][idx_dup[index]])
+            # check if epsg are the same, print a warning message
+            if len(np.unique(im_epsg)) > 1:
+                print('WARNING: there was an error as two S2 images do not have the same epsg,'+
+                      ' please open an issue on Github at https://github.com/kvos/CoastSat/issues'+
+                      ' and include your script so I can find out what happened.')
+            # find which images contain other images
+            contain_bools_list = []
+            for i,poly1 in enumerate(polygons):
+                contain_bools = []
+                for k,poly2 in enumerate(polygons):
+                    if k == i: 
+                        contain_bools.append(True)
+                        # print('%d*: '%k+str(poly1.contains(poly2)))
+                    else:
+                        # print('%d: '%k+str(poly1.contains(poly2)))
+                        contain_bools.append(poly1.contains(poly2))
+                contain_bools_list.append(contain_bools)
+            # look if one image contains all the others
+            contain_all = [np.all(_) for _ in contain_bools_list]
+            # if one image contains all the others, keep that one and delete the rest
+            if np.any(contain_all):
+                idx_keep = np.where(contain_all)[0][0]
+                for i in [_ for _ in range(len(idx_dup)) if not _ == idx_keep]:
+                    # print('removed %s'%(fn_im[i][-1]))
+                    # remove the 3 .tif files + the .txt file
+                    for k in range(4):  
+                        os.chmod(fn_im[i][k], 0o777)
+                        os.remove(fn_im[i][k])
+                    total_removed_step1 += 1
+        # load metadata again and update filenames
+        metadata = get_metadata(inputs) 
+        filenames = metadata[sat]['filenames']
+    
+    # find the pairs of images that are within 5 minutes of each other and merge them
+    time_delta = 5*60 # 5 minutes in seconds
+    dates = metadata[sat]['dates'].copy()
+    pairs = []
+    for i,date in enumerate(metadata[sat]['dates']):
+        # dummy value so it does not match it again
+        dates[i] = pytz.utc.localize(datetime(1,1,1) + timedelta(days=i+1))
+        # calculate time difference
+        time_diff = np.array([np.abs((date - _).total_seconds()) for _ in dates])
+        # find the matching times and add to pairs list
+        boolvec = time_diff <= time_delta
+        if np.sum(boolvec) == 0:
+            continue
+        else:
+            idx_dup = np.where(boolvec)[0][0]
+            pairs.append([i,idx_dup])
+    total_merged_step2 = len(pairs)        
+    # because they could be triplicates in S2 images, adjust the pairs for consecutive merges
+    for i in range(1,len(pairs)):
+        if pairs[i-1][1] == pairs[i][0]:
+            pairs[i][0] = pairs[i-1][0]
+            
+    # check also for quadruplicates and remove them 
+    pair_first = [_[0] for _ in pairs]
+    idx_remove_pair = []
+    for idx in np.unique(pair_first):
+        # quadruplicate if trying to merge 3 times the same image with a successive image
+        if sum(pair_first == idx) == 3: 
+            # remove the last image: 3 .tif files + the .txt file
+            idx_last = [pairs[_] for _ in np.where(pair_first == idx)[0]][-1][-1]
+            fn_im = [os.path.join(filepath, 'S2', '10m', filenames[idx_last]),
+                     os.path.join(filepath, 'S2', '20m',  filenames[idx_last].replace('10m','20m')),
+                     os.path.join(filepath, 'S2', '60m',  filenames[idx_last].replace('10m','60m')),
+                     os.path.join(filepath, 'S2', 'meta', filenames[idx_last].replace('_10m','').replace('.tif','.txt'))]
+            for k in range(4):  
+                os.chmod(fn_im[k], 0o777)
+                os.remove(fn_im[k]) 
+            # store the index of the pair to remove it outside the loop
+            idx_remove_pair.append(np.where(pair_first == idx)[0][-1])
+    # remove quadruplicates from list of pairs
+    pairs = [i for j, i in enumerate(pairs) if j not in idx_remove_pair]
+    
+    # for each pair of image, first check if one image completely contains the other
+    # in that case keep the larger image. Otherwise merge the two images.
+    for i,pair in enumerate(pairs):
+        # get filenames of all the files corresponding to the each image in the pair
+        fn_im = []
+        for index in range(len(pair)):
+            fn_im.append([os.path.join(filepath, 'S2', '10m', filenames[pair[index]]),
+                  os.path.join(filepath, 'S2', '20m',  filenames[pair[index]].replace('10m','20m')),
+                  os.path.join(filepath, 'S2', '60m',  filenames[pair[index]].replace('10m','60m')),
+                  os.path.join(filepath, 'S2', 'meta', filenames[pair[index]].replace('_10m','').replace('.tif','.txt'))])
+        # get polygon for first image
+        polygon0 = SDS_tools.get_image_bounds(fn_im[0][0])
+        im_epsg0 = metadata[sat]['epsg'][pair[0]]
+        # get polygon for second image
+        polygon1 = SDS_tools.get_image_bounds(fn_im[1][0])
+        im_epsg1 = metadata[sat]['epsg'][pair[1]]  
+        # check if epsg are the same
+        if not im_epsg0 == im_epsg1:
+            print('WARNING: there was an error as two S2 images do not have the same epsg,'+
+                  ' please open an issue on Github at https://github.com/kvos/CoastSat/issues'+
+                  ' and include your script so we can find out what happened.')
+            break
+        # check if one image contains the other one
+        if polygon0.contains(polygon1):  
+            # if polygon0 contains polygon1, remove files for polygon1
+            for k in range(4):  # remove the 3 .tif files + the .txt file
+                os.chmod(fn_im[1][k], 0o777)
+                os.remove(fn_im[1][k])
+            # print('removed 1')
+            continue
+        elif polygon1.contains(polygon0):
+            # if polygon1 contains polygon0, remove image0
+            for k in range(4):   # remove the 3 .tif files + the .txt file
+                os.chmod(fn_im[0][k], 0o777)
+                os.remove(fn_im[0][k])
+            # print('removed 0')
+            # adjust the order in case of triplicates
+            if i+1 < len(pairs):
+                if pairs[i+1][0] == pair[0]: pairs[i+1][0] = pairs[i][1]
+            continue
+        # otherwise merge the two images after masking the nodata values
+        else:
+            for index in range(len(pair)):
+                # read image
+                im_ms, georef, cloud_mask, im_extra, im_QA, im_nodata = SDS_preprocess.preprocess_single(fn_im[index], sat, False)
+                # in Sentinel2 images close to the edge of the image there are some artefacts,
+                # that are squares with constant pixel intensities. They need to be masked in the
+                # raster (GEOTIFF). It can be done using the image standard deviation, which
+                # indicates values close to 0 for the artefacts.
+                if len(im_ms) > 0:
+                    # calculate image std for the first 10m band
+                    im_std = SDS_tools.image_std(im_ms[:,:,0],1)
+                    # convert to binary
+                    im_binary = np.logical_or(im_std < 1e-6, np.isnan(im_std))
+                    # dilate to fill the edges (which have high std)
+                    mask10 = morphology.dilation(im_binary, morphology.square(3))
+                    # mask the 10m .tif file (add no_data where mask is True)
+                    SDS_tools.mask_raster(fn_im[index][0], mask10)    
+                    # now calculate the mask for the 20m band (SWIR1)
+                    # for the older version of the ee api calculate the image std again 
+                    if int(ee.__version__[-3:]) <= 201:
+                        # calculate std to create another mask for the 20m band (SWIR1)
+                        im_std = SDS_tools.image_std(im_extra,1)
+                        im_binary = np.logical_or(im_std < 1e-6, np.isnan(im_std))
+                        mask20 = morphology.dilation(im_binary, morphology.square(3))    
+                    # for the newer versions just resample the mask for the 10m bands
+                    else:
+                        # create mask for the 20m band (SWIR1) by resampling the 10m one
+                        mask20 = ndimage.zoom(mask10,zoom=1/2,order=0)
+                        mask20 = transform.resize(mask20, im_extra.shape, mode='constant',
+                                                  order=0, preserve_range=True)
+                        mask20 = mask20.astype(bool)     
+                    # mask the 20m .tif file (im_extra)
+                    SDS_tools.mask_raster(fn_im[index][1], mask20)
+                    # create a mask for the 60m QA band by resampling the 20m one
+                    mask60 = ndimage.zoom(mask20,zoom=1/3,order=0)
+                    mask60 = transform.resize(mask60, im_QA.shape, mode='constant',
+                                              order=0, preserve_range=True)
+                    mask60 = mask60.astype(bool)
+                    # mask the 60m .tif file (im_QA)
+                    SDS_tools.mask_raster(fn_im[index][2], mask60)   
+                    # make a figure for quality control/debugging
+                    # im_RGB = SDS_preprocess.rescale_image_intensity(im_ms[:,:,[2,1,0]], cloud_mask, 99.9)
+                    # fig,ax= plt.subplots(2,3,tight_layout=True)
+                    # ax[0,0].imshow(im_RGB)
+                    # ax[0,0].set_title('RGB original')
+                    # ax[1,0].imshow(mask10)
+                    # ax[1,0].set_title('Mask 10m')
+                    # ax[0,1].imshow(mask20)
+                    # ax[0,1].set_title('Mask 20m')
+                    # ax[1,1].imshow(mask60)
+                    # ax[1,1].set_title('Mask 60 m')
+                    # ax[0,2].imshow(im_QA)
+                    # ax[0,2].set_title('Im QA')
+                    # ax[1,2].imshow(im_nodata)
+                    # ax[1,2].set_title('Im nodata') 
+                else:
+                    continue
+    
+            # once all the pairs of .tif files have been masked with no_data, merge the using gdal_merge
+            fn_merged = os.path.join(filepath, 'merged.tif')
+            for k in range(3):  
+                # merge masked bands
+                gdal_merge.main(['', '-o', fn_merged, '-n', '0', fn_im[0][k], fn_im[1][k]])
+                # remove old files
+                os.chmod(fn_im[0][k], 0o777)
+                os.remove(fn_im[0][k])
+                os.chmod(fn_im[1][k], 0o777)
+                os.remove(fn_im[1][k])
+                # rename new file
+                fn_new = fn_im[0][k].split('.')[0] + '_merged.tif'
+                os.chmod(fn_merged, 0o777)
+                os.rename(fn_merged, fn_new)
+    
+            # open both metadata files
+            metadict0 = dict([])
+            with open(fn_im[0][3], 'r') as f:
+                metadict0['filename'] = f.readline().split('\t')[1].replace('\n','')
+                metadict0['acc_georef'] = float(f.readline().split('\t')[1].replace('\n',''))
+                metadict0['epsg'] = int(f.readline().split('\t')[1].replace('\n',''))
+            metadict1 = dict([])
+            with open(fn_im[1][3], 'r') as f:
+                metadict1['filename'] = f.readline().split('\t')[1].replace('\n','')
+                metadict1['acc_georef'] = float(f.readline().split('\t')[1].replace('\n',''))
+                metadict1['epsg'] = int(f.readline().split('\t')[1].replace('\n',''))
+            # check if both images have the same georef accuracy
+            if np.any(np.array([metadict0['acc_georef'],metadict1['acc_georef']]) == -1):
+                metadict0['georef'] = -1
+            # add new name
+            metadict0['filename'] =  metadict0['filename'].split('.')[0] + '_merged.tif'
+            # remove the old metadata.txt files
+            os.chmod(fn_im[0][3], 0o777)
+            os.remove(fn_im[0][3])
+            os.chmod(fn_im[1][3], 0o777)
+            os.remove(fn_im[1][3])        
+            # rewrite the .txt file with a new metadata file
+            fn_new = fn_im[0][3].split('.')[0] + '_merged.txt'
+            with open(fn_new, 'w') as f:
+                for key in metadict0.keys():
+                    f.write('%s\t%s\n'%(key,metadict0[key]))  
+                    
+            # update filenames list (in case there are triplicates)
+            filenames[pair[0]] = metadict0['filename']
+     
+    print('%d out of %d Sentinel-2 images were merged (overlapping or duplicate)'%(total_removed_step1+total_merged_step2,
+                                                                                   total_images))
+
+    # update the metadata dict
+    metadata_updated = get_metadata(inputs)
+
+    return metadata_updated

--- a/notebooks/coastsat/SDS_preprocess.py
+++ b/notebooks/coastsat/SDS_preprocess.py
@@ -1,0 +1,922 @@
+"""
+This module contains all the functions needed to preprocess the satellite images
+ before the shorelines can be extracted. This includes creating a cloud mask and
+pansharpening/downsampling the multispectral bands.
+
+Author: Kilian Vos, Water Research Laboratory, University of New South Wales
+"""
+
+# load modules
+import os
+import numpy as np
+import matplotlib.pyplot as plt
+import pdb
+
+# image processing modules
+import skimage.transform as transform
+import skimage.morphology as morphology
+import sklearn.decomposition as decomposition
+import skimage.exposure as exposure
+
+# other modules
+from osgeo import gdal
+from pylab import ginput
+import pickle
+import geopandas as gpd
+from shapely import geometry
+
+# CoastSat modules
+from coastsat import SDS_tools
+
+np.seterr(all='ignore') # raise/ignore divisions by 0 and nans
+
+# Main function to preprocess a satellite image (L5,L7,L8 or S2)
+def preprocess_single(fn, satname, cloud_mask_issue):
+    """
+    Reads the image and outputs the pansharpened/down-sampled multispectral bands,
+    the georeferencing vector of the image (coordinates of the upper left pixel),
+    the cloud mask, the QA band and a no_data image. 
+    For Landsat 7-8 it also outputs the panchromatic band and for Sentinel-2 it
+    also outputs the 20m SWIR band.
+
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    fn: str or list of str
+        filename of the .TIF file containing the image. For L7, L8 and S2 this 
+        is a list of filenames, one filename for each band at different
+        resolution (30m and 15m for Landsat 7-8, 10m, 20m, 60m for Sentinel-2)
+    satname: str
+        name of the satellite mission (e.g., 'L5')
+    cloud_mask_issue: boolean
+        True if there is an issue with the cloud mask and sand pixels are being masked on the images
+
+    Returns:
+    -----------
+    im_ms: np.array
+        3D array containing the pansharpened/down-sampled bands (B,G,R,NIR,SWIR1)
+    georef: np.array
+        vector of 6 elements [Xtr, Xscale, Xshear, Ytr, Yshear, Yscale] defining the
+        coordinates of the top-left pixel of the image
+    cloud_mask: np.array
+        2D cloud mask with True where cloud pixels are
+    im_extra : np.array
+        2D array containing the 20m resolution SWIR band for Sentinel-2 and the 15m resolution
+        panchromatic band for Landsat 7 and Landsat 8. This field is empty for Landsat 5.
+    im_QA: np.array
+        2D array containing the QA band, from which the cloud_mask can be computed.
+    im_nodata: np.array
+        2D array with True where no data values (-inf) are located
+
+    """
+
+    #=============================================================================================#
+    # L5 images
+    #=============================================================================================#
+    if satname == 'L5':
+
+        # read all bands
+        data = gdal.Open(fn, gdal.GA_ReadOnly)
+        georef = np.array(data.GetGeoTransform())
+        bands = [data.GetRasterBand(k + 1).ReadAsArray() for k in range(data.RasterCount)]
+        im_ms = np.stack(bands, 2)
+
+        # down-sample to 15 m (half of the original pixel size)
+        nrows = im_ms.shape[0]*2
+        ncols = im_ms.shape[1]*2
+
+        # create cloud mask
+        im_QA = im_ms[:,:,5]
+        im_ms = im_ms[:,:,:-1]
+        cloud_mask = create_cloud_mask(im_QA, satname, cloud_mask_issue)
+
+        # resize the image using bilinear interpolation (order 1)
+        im_ms = transform.resize(im_ms,(nrows, ncols), order=1, preserve_range=True,
+                                 mode='constant')
+        # resize the image using nearest neighbour interpolation (order 0)
+        cloud_mask = transform.resize(cloud_mask, (nrows, ncols), order=0, preserve_range=True,
+                                      mode='constant').astype('bool_')
+
+        # adjust georeferencing vector to the new image size
+        # scale becomes 15m and the origin is adjusted to the center of new top left pixel
+        georef[1] = 15
+        georef[5] = -15
+        georef[0] = georef[0] + 7.5
+        georef[3] = georef[3] - 7.5
+        
+        # check if -inf or nan values on any band and eventually add those pixels to cloud mask        
+        im_nodata = np.zeros(cloud_mask.shape).astype(bool)
+        for k in range(im_ms.shape[2]):
+            im_inf = np.isin(im_ms[:,:,k], -np.inf)
+            im_nan = np.isnan(im_ms[:,:,k])
+            im_nodata = np.logical_or(np.logical_or(im_nodata, im_inf), im_nan)
+        # check if there are pixels with 0 intensity in the Green, NIR and SWIR bands and add those
+        # to the cloud mask as otherwise they will cause errors when calculating the NDWI and MNDWI
+        im_zeros = np.ones(cloud_mask.shape).astype(bool)
+        for k in [1,3,4]: # loop through the Green, NIR and SWIR bands
+            im_zeros = np.logical_and(np.isin(im_ms[:,:,k],0), im_zeros)
+        # add zeros to im nodata
+        im_nodata = np.logical_or(im_zeros, im_nodata)   
+        # update cloud mask with all the nodata pixels
+        cloud_mask = np.logical_or(cloud_mask, im_nodata)
+        
+        # no extra image for Landsat 5 (they are all 30 m bands)
+        im_extra = []
+
+    #=============================================================================================#
+    # L7 images
+    #=============================================================================================#
+    elif satname == 'L7':
+
+        # read pan image
+        fn_pan = fn[0]
+        data = gdal.Open(fn_pan, gdal.GA_ReadOnly)
+        georef = np.array(data.GetGeoTransform())
+        bands = [data.GetRasterBand(k + 1).ReadAsArray() for k in range(data.RasterCount)]
+        im_pan = np.stack(bands, 2)[:,:,0]
+
+        # size of pan image
+        nrows = im_pan.shape[0]
+        ncols = im_pan.shape[1]
+
+        # read ms image
+        fn_ms = fn[1]
+        data = gdal.Open(fn_ms, gdal.GA_ReadOnly)
+        bands = [data.GetRasterBand(k + 1).ReadAsArray() for k in range(data.RasterCount)]
+        im_ms = np.stack(bands, 2)
+
+        # create cloud mask
+        im_QA = im_ms[:,:,5]
+        cloud_mask = create_cloud_mask(im_QA, satname, cloud_mask_issue)
+
+        # resize the image using bilinear interpolation (order 1)
+        im_ms = im_ms[:,:,:5]
+        im_ms = transform.resize(im_ms,(nrows, ncols), order=1, preserve_range=True,
+                                 mode='constant')
+        # resize the image using nearest neighbour interpolation (order 0)
+        cloud_mask = transform.resize(cloud_mask, (nrows, ncols), order=0, preserve_range=True,
+                                      mode='constant').astype('bool_')
+        # check if -inf or nan values on any band and eventually add those pixels to cloud mask        
+        im_nodata = np.zeros(cloud_mask.shape).astype(bool)
+        for k in range(im_ms.shape[2]):
+            im_inf = np.isin(im_ms[:,:,k], -np.inf)
+            im_nan = np.isnan(im_ms[:,:,k])
+            im_nodata = np.logical_or(np.logical_or(im_nodata, im_inf), im_nan)
+        # check if there are pixels with 0 intensity in the Green, NIR and SWIR bands and add those
+        # to the cloud mask as otherwise they will cause errors when calculating the NDWI and MNDWI
+        im_zeros = np.ones(cloud_mask.shape).astype(bool)
+        for k in [1,3,4]: # loop through the Green, NIR and SWIR bands
+            im_zeros = np.logical_and(np.isin(im_ms[:,:,k],0), im_zeros)
+        # add zeros to im nodata
+        im_nodata = np.logical_or(im_zeros, im_nodata)   
+        # update cloud mask with all the nodata pixels
+        cloud_mask = np.logical_or(cloud_mask, im_nodata)
+
+        # pansharpen Green, Red, NIR (where there is overlapping with pan band in L7)
+        try:
+            im_ms_ps = pansharpen(im_ms[:,:,[1,2,3]], im_pan, cloud_mask)
+        except: # if pansharpening fails, keep downsampled bands (for long runs)
+            im_ms_ps = im_ms[:,:,[1,2,3]]
+        # add downsampled Blue and SWIR1 bands
+        im_ms_ps = np.append(im_ms[:,:,[0]], im_ms_ps, axis=2)
+        im_ms_ps = np.append(im_ms_ps, im_ms[:,:,[4]], axis=2)
+
+        im_ms = im_ms_ps.copy()
+        # the extra image is the 15m panchromatic band
+        im_extra = im_pan
+
+    #=============================================================================================#
+    # L8 images
+    #=============================================================================================#
+    elif satname == 'L8':
+
+        # read pan image
+        fn_pan = fn[0]
+        data = gdal.Open(fn_pan, gdal.GA_ReadOnly)
+        georef = np.array(data.GetGeoTransform())
+        bands = [data.GetRasterBand(k + 1).ReadAsArray() for k in range(data.RasterCount)]
+        im_pan = np.stack(bands, 2)[:,:,0]
+
+        # size of pan image
+        nrows = im_pan.shape[0]
+        ncols = im_pan.shape[1]
+
+        # read ms image
+        fn_ms = fn[1]
+        data = gdal.Open(fn_ms, gdal.GA_ReadOnly)
+        bands = [data.GetRasterBand(k + 1).ReadAsArray() for k in range(data.RasterCount)]
+        im_ms = np.stack(bands, 2)
+
+        # create cloud mask
+        im_QA = im_ms[:,:,5]
+        cloud_mask = create_cloud_mask(im_QA, satname, cloud_mask_issue)
+
+        # resize the image using bilinear interpolation (order 1)
+        im_ms = im_ms[:,:,:5]
+        im_ms = transform.resize(im_ms,(nrows, ncols), order=1, preserve_range=True,
+                                 mode='constant')
+        # resize the image using nearest neighbour interpolation (order 0)
+        cloud_mask = transform.resize(cloud_mask, (nrows, ncols), order=0, preserve_range=True,
+                                      mode='constant').astype('bool_')
+        # check if -inf or nan values on any band and eventually add those pixels to cloud mask        
+        im_nodata = np.zeros(cloud_mask.shape).astype(bool)
+        for k in range(im_ms.shape[2]):
+            im_inf = np.isin(im_ms[:,:,k], -np.inf)
+            im_nan = np.isnan(im_ms[:,:,k])
+            im_nodata = np.logical_or(np.logical_or(im_nodata, im_inf), im_nan)
+        # check if there are pixels with 0 intensity in the Green, NIR and SWIR bands and add those
+        # to the cloud mask as otherwise they will cause errors when calculating the NDWI and MNDWI
+        im_zeros = np.ones(cloud_mask.shape).astype(bool)
+        for k in [1,3,4]: # loop through the Green, NIR and SWIR bands
+            im_zeros = np.logical_and(np.isin(im_ms[:,:,k],0), im_zeros)
+        # add zeros to im nodata
+        im_nodata = np.logical_or(im_zeros, im_nodata)   
+        # update cloud mask with all the nodata pixels
+        cloud_mask = np.logical_or(cloud_mask, im_nodata)
+        
+        # pansharpen Blue, Green, Red (where there is overlapping with pan band in L8)
+        try:
+            im_ms_ps = pansharpen(im_ms[:,:,[0,1,2]], im_pan, cloud_mask)
+        except: # if pansharpening fails, keep downsampled bands (for long runs)
+            im_ms_ps = im_ms[:,:,[0,1,2]]
+        # add downsampled NIR and SWIR1 bands
+        im_ms_ps = np.append(im_ms_ps, im_ms[:,:,[3,4]], axis=2)
+
+        im_ms = im_ms_ps.copy()
+        # the extra image is the 15m panchromatic band
+        im_extra = im_pan
+
+    #=============================================================================================#
+    # S2 images
+    #=============================================================================================#
+    if satname == 'S2':
+
+        # read 10m bands (R,G,B,NIR)
+        fn10 = fn[0]
+        data = gdal.Open(fn10, gdal.GA_ReadOnly)
+        georef = np.array(data.GetGeoTransform())
+        bands = [data.GetRasterBand(k + 1).ReadAsArray() for k in range(data.RasterCount)]
+        im10 = np.stack(bands, 2)
+        im10 = im10/10000 # TOA scaled to 10000
+
+        # if image contains only zeros (can happen with S2), skip the image
+        if sum(sum(sum(im10))) < 1:
+            im_ms = []
+            georef = []
+            # skip the image by giving it a full cloud_mask
+            cloud_mask = np.ones((im10.shape[0],im10.shape[1])).astype('bool')
+            return im_ms, georef, cloud_mask, [], [], []
+
+        # size of 10m bands
+        nrows = im10.shape[0]
+        ncols = im10.shape[1]
+
+        # read 20m band (SWIR1)
+        fn20 = fn[1]
+        data = gdal.Open(fn20, gdal.GA_ReadOnly)
+        bands = [data.GetRasterBand(k + 1).ReadAsArray() for k in range(data.RasterCount)]
+        im20 = np.stack(bands, 2)
+        im20 = im20[:,:,0]
+        im20 = im20/10000 # TOA scaled to 10000
+
+        # resize the image using bilinear interpolation (order 1)
+        im_swir = transform.resize(im20, (nrows, ncols), order=1, preserve_range=True,
+                                   mode='constant')
+        im_swir = np.expand_dims(im_swir, axis=2)
+
+        # append down-sampled SWIR1 band to the other 10m bands
+        im_ms = np.append(im10, im_swir, axis=2)
+
+        # create cloud mask using 60m QA band (not as good as Landsat cloud cover)
+        fn60 = fn[2]
+        data = gdal.Open(fn60, gdal.GA_ReadOnly)
+        bands = [data.GetRasterBand(k + 1).ReadAsArray() for k in range(data.RasterCount)]
+        im60 = np.stack(bands, 2)
+        im_QA = im60[:,:,0]
+        cloud_mask = create_cloud_mask(im_QA, satname, cloud_mask_issue)
+        # resize the cloud mask using nearest neighbour interpolation (order 0)
+        cloud_mask = transform.resize(cloud_mask,(nrows, ncols), order=0, preserve_range=True,
+                                      mode='constant')
+        # check if -inf or nan values on any band and create nodata image
+        im_nodata = np.zeros(cloud_mask.shape).astype(bool)
+        for k in range(im_ms.shape[2]):
+            im_inf = np.isin(im_ms[:,:,k], -np.inf)
+            im_nan = np.isnan(im_ms[:,:,k])
+            im_nodata = np.logical_or(np.logical_or(im_nodata, im_inf), im_nan)
+        # check if there are pixels with 0 intensity in the Green, NIR and SWIR bands and add those
+        # to the cloud mask as otherwise they will cause errors when calculating the NDWI and MNDWI
+        im_zeros = np.ones(im_nodata.shape).astype(bool)
+        im_zeros = np.logical_and(np.isin(im_ms[:,:,1],0), im_zeros) # Green
+        im_zeros = np.logical_and(np.isin(im_ms[:,:,3],0), im_zeros) # NIR
+        im_20_zeros = transform.resize(np.isin(im20,0),(nrows, ncols), order=0,
+                                       preserve_range=True, mode='constant').astype(bool)
+        im_zeros = np.logical_and(im_20_zeros, im_zeros) # SWIR1
+        # add to im_nodata
+        im_nodata = np.logical_or(im_zeros, im_nodata)
+        # dilate if image was merged as there could be issues at the edges
+        if 'merged' in fn10:
+            im_nodata = morphology.dilation(im_nodata,morphology.square(5))
+            
+        # update cloud mask with all the nodata pixels
+        cloud_mask = np.logical_or(cloud_mask, im_nodata)
+
+        # the extra image is the 20m SWIR band
+        im_extra = im20
+
+    return im_ms, georef, cloud_mask, im_extra, im_QA, im_nodata
+
+
+###################################################################################################
+# AUXILIARY FUNCTIONS
+###################################################################################################
+
+def create_cloud_mask(im_QA, satname, cloud_mask_issue):
+    """
+    Creates a cloud mask using the information contained in the QA band.
+
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    im_QA: np.array
+        Image containing the QA band
+    satname: string
+        short name for the satellite: ```'L5', 'L7', 'L8' or 'S2'```
+    cloud_mask_issue: boolean
+        True if there is an issue with the cloud mask and sand pixels are being
+        erroneously masked on the images
+
+    Returns:
+    -----------
+    cloud_mask : np.array
+        boolean array with True if a pixel is cloudy and False otherwise
+        
+    """
+
+    # convert QA bits (the bits allocated to cloud cover vary depending on the satellite mission)
+    if satname == 'L8':
+        cloud_values = [2800, 2804, 2808, 2812, 6896, 6900, 6904, 6908]
+    elif satname == 'L7' or satname == 'L5' or satname == 'L4':
+        cloud_values = [752, 756, 760, 764]
+    elif satname == 'S2':
+        cloud_values = [1024, 2048] # 1024 = dense cloud, 2048 = cirrus clouds
+
+    # find which pixels have bits corresponding to cloud values
+    cloud_mask = np.isin(im_QA, cloud_values)
+
+    # remove cloud pixels that form very thin features. These are beach or swash pixels that are
+    # erroneously identified as clouds by the CFMASK algorithm applied to the images by the USGS.
+    if sum(sum(cloud_mask)) > 0 and sum(sum(~cloud_mask)) > 0:
+        morphology.remove_small_objects(cloud_mask, min_size=10, connectivity=1, in_place=True)
+
+        if cloud_mask_issue:
+            elem = morphology.square(3) # use a square of width 3 pixels
+            cloud_mask = morphology.binary_opening(cloud_mask,elem) # perform image opening
+            # remove objects with less than 25 connected pixels
+            morphology.remove_small_objects(cloud_mask, min_size=25, connectivity=1, in_place=True)
+
+    return cloud_mask
+
+def hist_match(source, template):
+    """
+    Adjust the pixel values of a grayscale image such that its histogram matches
+    that of a target image.
+
+    Arguments:
+    -----------
+    source: np.array
+        Image to transform; the histogram is computed over the flattened
+        array
+    template: np.array
+        Template image; can have different dimensions to source
+        
+    Returns:
+    -----------
+    matched: np.array
+        The transformed output image
+        
+    """
+
+    oldshape = source.shape
+    source = source.ravel()
+    template = template.ravel()
+
+    # get the set of unique pixel values and their corresponding indices and
+    # counts
+    s_values, bin_idx, s_counts = np.unique(source, return_inverse=True,
+                                            return_counts=True)
+    t_values, t_counts = np.unique(template, return_counts=True)
+
+    # take the cumsum of the counts and normalize by the number of pixels to
+    # get the empirical cumulative distribution functions for the source and
+    # template images (maps pixel value --> quantile)
+    s_quantiles = np.cumsum(s_counts).astype(np.float64)
+    s_quantiles /= s_quantiles[-1]
+    t_quantiles = np.cumsum(t_counts).astype(np.float64)
+    t_quantiles /= t_quantiles[-1]
+
+    # interpolate linearly to find the pixel values in the template image
+    # that correspond most closely to the quantiles in the source image
+    interp_t_values = np.interp(s_quantiles, t_quantiles, t_values)
+
+    return interp_t_values[bin_idx].reshape(oldshape)
+
+def pansharpen(im_ms, im_pan, cloud_mask):
+    """
+    Pansharpens a multispectral image, using the panchromatic band and a cloud mask.
+    A PCA is applied to the image, then the 1st PC is replaced, after histogram 
+    matching with the panchromatic band. Note that it is essential to match the
+    histrograms of the 1st PC and the panchromatic band before replacing and 
+    inverting the PCA.
+
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    im_ms: np.array
+        Multispectral image to pansharpen (3D)
+    im_pan: np.array
+        Panchromatic band (2D)
+    cloud_mask: np.array
+        2D cloud mask with True where cloud pixels are
+
+    Returns:
+    -----------
+    im_ms_ps: np.ndarray
+        Pansharpened multispectral image (3D)
+        
+    """
+
+    # reshape image into vector and apply cloud mask
+    vec = im_ms.reshape(im_ms.shape[0] * im_ms.shape[1], im_ms.shape[2])
+    vec_mask = cloud_mask.reshape(im_ms.shape[0] * im_ms.shape[1])
+    vec = vec[~vec_mask, :]
+    # apply PCA to multispectral bands
+    pca = decomposition.PCA()
+    vec_pcs = pca.fit_transform(vec)
+
+    # replace 1st PC with pan band (after matching histograms)
+    vec_pan = im_pan.reshape(im_pan.shape[0] * im_pan.shape[1])
+    vec_pan = vec_pan[~vec_mask]
+    vec_pcs[:,0] = hist_match(vec_pan, vec_pcs[:,0])
+    vec_ms_ps = pca.inverse_transform(vec_pcs)
+
+    # reshape vector into image
+    vec_ms_ps_full = np.ones((len(vec_mask), im_ms.shape[2])) * np.nan
+    vec_ms_ps_full[~vec_mask,:] = vec_ms_ps
+    im_ms_ps = vec_ms_ps_full.reshape(im_ms.shape[0], im_ms.shape[1], im_ms.shape[2])
+
+    return im_ms_ps
+
+
+def rescale_image_intensity(im, cloud_mask, prob_high):
+    """
+    Rescales the intensity of an image (multispectral or single band) by applying
+    a cloud mask and clipping the prob_high upper percentile. This functions allows
+    to stretch the contrast of an image, only for visualisation purposes.
+
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    im: np.array
+        Image to rescale, can be 3D (multispectral) or 2D (single band)
+    cloud_mask: np.array
+        2D cloud mask with True where cloud pixels are
+    prob_high: float
+        probability of exceedence used to calculate the upper percentile
+
+    Returns:
+    -----------
+    im_adj: np.array
+        rescaled image
+    """
+
+    # lower percentile is set to 0
+    prc_low = 0
+
+    # reshape the 2D cloud mask into a 1D vector
+    vec_mask = cloud_mask.reshape(im.shape[0] * im.shape[1])
+
+    # if image contains several bands, stretch the contrast for each band
+    if len(im.shape) > 2:
+        # reshape into a vector
+        vec =  im.reshape(im.shape[0] * im.shape[1], im.shape[2])
+        # initiliase with NaN values
+        vec_adj = np.ones((len(vec_mask), im.shape[2])) * np.nan
+        # loop through the bands
+        for i in range(im.shape[2]):
+            # find the higher percentile (based on prob)
+            prc_high = np.percentile(vec[~vec_mask, i], prob_high)
+            # clip the image around the 2 percentiles and rescale the contrast
+            vec_rescaled = exposure.rescale_intensity(vec[~vec_mask, i],
+                                                      in_range=(prc_low, prc_high))
+            vec_adj[~vec_mask,i] = vec_rescaled
+        # reshape into image
+        im_adj = vec_adj.reshape(im.shape[0], im.shape[1], im.shape[2])
+
+    # if image only has 1 bands (grayscale image)
+    else:
+        vec =  im.reshape(im.shape[0] * im.shape[1])
+        vec_adj = np.ones(len(vec_mask)) * np.nan
+        prc_high = np.percentile(vec[~vec_mask], prob_high)
+        vec_rescaled = exposure.rescale_intensity(vec[~vec_mask], in_range=(prc_low, prc_high))
+        vec_adj[~vec_mask] = vec_rescaled
+        im_adj = vec_adj.reshape(im.shape[0], im.shape[1])
+
+    return im_adj
+
+def create_jpg(im_ms, cloud_mask, date, satname, filepath):
+    """
+    Saves a .jpg file with the RGB image as well as the NIR and SWIR1 grayscale images.
+    This functions can be modified to obtain different visualisations of the 
+    multispectral images.
+
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    im_ms: np.array
+        3D array containing the pansharpened/down-sampled bands (B,G,R,NIR,SWIR1)
+    cloud_mask: np.array
+        2D cloud mask with True where cloud pixels are
+    date: str
+        string containing the date at which the image was acquired
+    satname: str
+        name of the satellite mission (e.g., 'L5')
+
+    Returns:
+    -----------
+        Saves a .jpg image corresponding to the preprocessed satellite image
+
+    """
+
+    # rescale image intensity for display purposes
+    im_RGB = rescale_image_intensity(im_ms[:,:,[2,1,0]], cloud_mask, 99.9)
+#    im_NIR = rescale_image_intensity(im_ms[:,:,3], cloud_mask, 99.9)
+#    im_SWIR = rescale_image_intensity(im_ms[:,:,4], cloud_mask, 99.9)
+
+    # make figure (just RGB)
+    fig = plt.figure()
+    fig.set_size_inches([18,9])
+    fig.set_tight_layout(True)
+    ax1 = fig.add_subplot(111)
+    ax1.axis('off')
+    ax1.imshow(im_RGB)
+    ax1.set_title(date + '   ' + satname, fontsize=16)
+
+#    if im_RGB.shape[1] > 2*im_RGB.shape[0]:
+#        ax1 = fig.add_subplot(311)
+#        ax2 = fig.add_subplot(312)
+#        ax3 = fig.add_subplot(313)
+#    else:
+#        ax1 = fig.add_subplot(131)
+#        ax2 = fig.add_subplot(132)
+#        ax3 = fig.add_subplot(133)
+#    # RGB
+#    ax1.axis('off')
+#    ax1.imshow(im_RGB)
+#    ax1.set_title(date + '   ' + satname, fontsize=16)
+#    # NIR
+#    ax2.axis('off')
+#    ax2.imshow(im_NIR, cmap='seismic')
+#    ax2.set_title('Near Infrared', fontsize=16)
+#    # SWIR
+#    ax3.axis('off')
+#    ax3.imshow(im_SWIR, cmap='seismic')
+#    ax3.set_title('Short-wave Infrared', fontsize=16)
+
+    # save figure
+    plt.rcParams['savefig.jpeg_quality'] = 100
+    fig.savefig(os.path.join(filepath,
+                             date + '_' + satname + '.jpg'), dpi=150)
+    plt.close()
+
+
+def save_jpg(metadata, settings, **kwargs):
+    """
+    Saves a .jpg image for all the images contained in metadata.
+
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    metadata: dict
+        contains all the information about the satellite images that were downloaded
+    settings: dict with the following keys
+        'inputs': dict
+            input parameters (sitename, filepath, polygon, dates, sat_list)
+        'cloud_thresh': float
+            value between 0 and 1 indicating the maximum cloud fraction in 
+            the cropped image that is accepted
+        'cloud_mask_issue': boolean
+            True if there is an issue with the cloud mask and sand pixels
+            are erroneously being masked on the images
+            
+    Returns:
+    -----------
+    Stores the images as .jpg in a folder named /preprocessed
+    
+    """
+    
+    sitename = settings['inputs']['sitename']
+    cloud_thresh = settings['cloud_thresh']
+    filepath_data = settings['inputs']['filepath']
+
+    # create subfolder to store the jpg files
+    filepath_jpg = os.path.join(filepath_data, sitename, 'jpg_files', 'preprocessed')
+    if not os.path.exists(filepath_jpg):
+            os.makedirs(filepath_jpg)
+
+    # loop through satellite list
+    for satname in metadata.keys():
+
+        filepath = SDS_tools.get_filepath(settings['inputs'],satname)
+        filenames = metadata[satname]['filenames']
+
+        # loop through images
+        for i in range(len(filenames)):
+            # image filename
+            fn = SDS_tools.get_filenames(filenames[i],filepath, satname)
+            # read and preprocess image
+            im_ms, georef, cloud_mask, im_extra, im_QA, im_nodata = preprocess_single(fn, satname, settings['cloud_mask_issue'])
+
+            # compute cloud_cover percentage (with no data pixels)
+            cloud_cover_combined = np.divide(sum(sum(cloud_mask.astype(int))),
+                                    (cloud_mask.shape[0]*cloud_mask.shape[1]))
+            if cloud_cover_combined > 0.99: # if 99% of cloudy pixels in image skip
+                continue
+
+            # remove no data pixels from the cloud mask (for example L7 bands of no data should not be accounted for)
+            cloud_mask_adv = np.logical_xor(cloud_mask, im_nodata)
+            # compute updated cloud cover percentage (without no data pixels)
+            cloud_cover = np.divide(sum(sum(cloud_mask_adv.astype(int))),
+                                    (sum(sum((~im_nodata).astype(int)))))
+            # skip image if cloud cover is above threshold
+            if cloud_cover > cloud_thresh or cloud_cover == 1:
+                continue
+            # save .jpg with date and satellite in the title
+            date = filenames[i][:19]
+            plt.ioff()  # turning interactive plotting off
+            create_jpg(im_ms, cloud_mask, date, satname, filepath_jpg)
+
+    # print the location where the images have been saved
+    print('Satellite images saved as .jpg in ' + os.path.join(filepath_data, sitename,
+                                                    'jpg_files', 'preprocessed'))
+
+def get_reference_sl(metadata, settings):
+    """
+    Allows the user to manually digitize a reference shoreline that is used seed
+    the shoreline detection algorithm. The reference shoreline helps to detect 
+    the outliers, making the shoreline detection more robust.
+
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    metadata: dict
+        contains all the information about the satellite images that were downloaded
+    settings: dict with the following keys
+        'inputs': dict
+            input parameters (sitename, filepath, polygon, dates, sat_list)
+        'cloud_thresh': float
+            value between 0 and 1 indicating the maximum cloud fraction in 
+            the cropped image that is accepted
+        'cloud_mask_issue': boolean
+            True if there is an issue with the cloud mask and sand pixels
+            are erroneously being masked on the images
+        'output_epsg': int
+            output spatial reference system as EPSG code
+
+    Returns:
+    -----------
+    reference_shoreline: np.array
+        coordinates of the reference shoreline that was manually digitized. 
+        This is also saved as a .pkl and .geojson file.
+
+    """
+
+    sitename = settings['inputs']['sitename']
+    filepath_data = settings['inputs']['filepath']
+    pts_coords = []
+    # check if reference shoreline already exists in the corresponding folder
+    filepath = os.path.join(filepath_data, sitename)
+    filename = sitename + '_reference_shoreline.pkl'
+    # if it exist, load it and return it
+    if filename in os.listdir(filepath):
+        print('Reference shoreline already exists and was loaded')
+        with open(os.path.join(filepath, sitename + '_reference_shoreline.pkl'), 'rb') as f:
+            refsl = pickle.load(f)
+        return refsl
+    
+    # otherwise get the user to manually digitise a shoreline on S2, L8 or L5 images (no L7 because of scan line error)
+    else:
+        # first try to use S2 images (10m res for manually digitizing the reference shoreline)
+        if 'S2' in metadata.keys():
+            satname = 'S2'
+            filepath = SDS_tools.get_filepath(settings['inputs'],satname)
+            filenames = metadata[satname]['filenames']
+        # if no S2 images, try L8  (15m res in the RGB with pansharpening)
+        elif not 'S2' in metadata.keys() and 'L8' in metadata.keys():
+            satname = 'L8'
+            filepath = SDS_tools.get_filepath(settings['inputs'],satname)
+            filenames = metadata[satname]['filenames']
+        # if no S2 images and no L8, use L5 images (L7 images have black diagonal bands making it
+        # hard to manually digitize a shoreline)
+        elif not 'S2' in metadata.keys() and not 'L8' in metadata.keys() and 'L5' in metadata.keys():
+            satname = 'L5'
+            filepath = SDS_tools.get_filepath(settings['inputs'],satname)
+            filenames = metadata[satname]['filenames']
+        else:
+            raise Exception('You cannot digitize the shoreline on L7 images (because of gaps in the images), add another L8, S2 or L5 to your dataset.')
+            
+        # create figure
+        fig, ax = plt.subplots(1,1, figsize=[18,9], tight_layout=True)
+        mng = plt.get_current_fig_manager()
+        mng.window.showMaximized()
+        # loop trhough the images
+        for i in range(len(filenames)):
+
+            # read image
+            fn = SDS_tools.get_filenames(filenames[i],filepath, satname)
+            im_ms, georef, cloud_mask, im_extra, im_QA, im_nodata = preprocess_single(fn, satname, settings['cloud_mask_issue'])
+
+            # compute cloud_cover percentage (with no data pixels)
+            cloud_cover_combined = np.divide(sum(sum(cloud_mask.astype(int))),
+                                    (cloud_mask.shape[0]*cloud_mask.shape[1]))
+            if cloud_cover_combined > 0.99: # if 99% of cloudy pixels in image skip
+                continue
+
+            # remove no data pixels from the cloud mask (for example L7 bands of no data should not be accounted for)
+            cloud_mask_adv = np.logical_xor(cloud_mask, im_nodata)
+            # compute updated cloud cover percentage (without no data pixels)
+            cloud_cover = np.divide(sum(sum(cloud_mask_adv.astype(int))),
+                                    (sum(sum((~im_nodata).astype(int)))))
+
+            # skip image if cloud cover is above threshold
+            if cloud_cover > settings['cloud_thresh']:
+                continue
+
+            # rescale image intensity for display purposes
+            im_RGB = rescale_image_intensity(im_ms[:,:,[2,1,0]], cloud_mask, 99.9)
+
+            # plot the image RGB on a figure
+            ax.axis('off')
+            ax.imshow(im_RGB)
+
+            # decide if the image if good enough for digitizing the shoreline
+            ax.set_title('Press <right arrow> if image is clear enough to digitize the shoreline.\n' +
+                      'If the image is cloudy press <left arrow> to get another image', fontsize=14)
+            # set a key event to accept/reject the detections (see https://stackoverflow.com/a/15033071)
+            # this variable needs to be immuatable so we can access it after the keypress event
+            skip_image = False
+            key_event = {}
+            def press(event):
+                # store what key was pressed in the dictionary
+                key_event['pressed'] = event.key
+            # let the user press a key, right arrow to keep the image, left arrow to skip it
+            # to break the loop the user can press 'escape'
+            while True:
+                btn_keep = plt.text(1.1, 0.9, 'keep ⇨', size=12, ha="right", va="top",
+                                    transform=ax.transAxes,
+                                    bbox=dict(boxstyle="square", ec='k',fc='w'))
+                btn_skip = plt.text(-0.1, 0.9, '⇦ skip', size=12, ha="left", va="top",
+                                    transform=ax.transAxes,
+                                    bbox=dict(boxstyle="square", ec='k',fc='w'))
+                btn_esc = plt.text(0.5, 0, '<esc> to quit', size=12, ha="center", va="top",
+                                    transform=ax.transAxes,
+                                    bbox=dict(boxstyle="square", ec='k',fc='w'))
+                plt.draw()
+                fig.canvas.mpl_connect('key_press_event', press)
+                plt.waitforbuttonpress()
+                # after button is pressed, remove the buttons
+                btn_skip.remove()
+                btn_keep.remove()
+                btn_esc.remove()
+                # keep/skip image according to the pressed key, 'escape' to break the loop
+                if key_event.get('pressed') == 'right':
+                    skip_image = False
+                    break
+                elif key_event.get('pressed') == 'left':
+                    skip_image = True
+                    break
+                elif key_event.get('pressed') == 'escape':
+                    plt.close()
+                    raise StopIteration('User cancelled checking shoreline detection')
+                else:
+                    plt.waitforbuttonpress()
+                    
+            if skip_image:
+                ax.clear()
+                continue
+            else:
+                # create two new buttons
+                add_button = plt.text(0, 0.9, 'add', size=16, ha="left", va="top",
+                                       transform=plt.gca().transAxes,
+                                       bbox=dict(boxstyle="square", ec='k',fc='w'))
+                end_button = plt.text(1, 0.9, 'end', size=16, ha="right", va="top",
+                                       transform=plt.gca().transAxes,
+                                       bbox=dict(boxstyle="square", ec='k',fc='w'))
+                # add multiple reference shorelines (until user clicks on <end> button)
+                pts_sl = np.expand_dims(np.array([np.nan, np.nan]),axis=0)
+                geoms = []
+                while 1:
+                    add_button.set_visible(False)
+                    end_button.set_visible(False)
+                    # update title (instructions)
+                    ax.set_title('Click points along the shoreline (enough points to capture the beach curvature).\n' +
+                              'Start at one end of the beach.\n' + 'When finished digitizing, click <ENTER>',
+                              fontsize=14)
+                    plt.draw()
+
+                    # let user click on the shoreline
+                    pts = ginput(n=50000, timeout=-1, show_clicks=True)
+                    pts_pix = np.array(pts)
+                    # convert pixel coordinates to world coordinates
+                    pts_world = SDS_tools.convert_pix2world(pts_pix[:,[1,0]], georef)
+
+                    # interpolate between points clicked by the user (1m resolution)
+                    pts_world_interp = np.expand_dims(np.array([np.nan, np.nan]),axis=0)
+                    for k in range(len(pts_world)-1):
+                        pt_dist = np.linalg.norm(pts_world[k,:]-pts_world[k+1,:])
+                        xvals = np.arange(0,pt_dist)
+                        yvals = np.zeros(len(xvals))
+                        pt_coords = np.zeros((len(xvals),2))
+                        pt_coords[:,0] = xvals
+                        pt_coords[:,1] = yvals
+                        phi = 0
+                        deltax = pts_world[k+1,0] - pts_world[k,0]
+                        deltay = pts_world[k+1,1] - pts_world[k,1]
+                        phi = np.pi/2 - np.math.atan2(deltax, deltay)
+                        tf = transform.EuclideanTransform(rotation=phi, translation=pts_world[k,:])
+                        pts_world_interp = np.append(pts_world_interp,tf(pt_coords), axis=0)
+                    pts_world_interp = np.delete(pts_world_interp,0,axis=0)
+
+                    # save as geometry (to create .geojson file later)
+                    geoms.append(geometry.LineString(pts_world_interp))
+
+                    # convert to pixel coordinates and plot
+                    pts_pix_interp = SDS_tools.convert_world2pix(pts_world_interp, georef)
+                    pts_sl = np.append(pts_sl, pts_world_interp, axis=0)
+                    ax.plot(pts_pix_interp[:,0], pts_pix_interp[:,1], 'r--')
+                    ax.plot(pts_pix_interp[0,0], pts_pix_interp[0,1],'ko')
+                    ax.plot(pts_pix_interp[-1,0], pts_pix_interp[-1,1],'ko')
+
+                    # update title and buttons
+                    add_button.set_visible(True)
+                    end_button.set_visible(True)
+                    ax.set_title('click on <add> to digitize another shoreline or on <end> to finish and save the shoreline(s)',
+                              fontsize=14)
+                    plt.draw()
+
+                    # let the user click again (<add> another shoreline or <end>)
+                    pt_input = ginput(n=1, timeout=-1, show_clicks=False)
+                    pt_input = np.array(pt_input)
+
+                    # if user clicks on <end>, save the points and break the loop
+                    if pt_input[0][0] > im_ms.shape[1]/2:
+                        add_button.set_visible(False)
+                        end_button.set_visible(False)
+                        plt.title('Reference shoreline saved as ' + sitename + '_reference_shoreline.pkl and ' + sitename + '_reference_shoreline.geojson')
+                        plt.draw()
+                        ginput(n=1, timeout=3, show_clicks=False)
+                        plt.close()
+                        break
+
+                pts_sl = np.delete(pts_sl,0,axis=0)
+                # convert world image coordinates to user-defined coordinate system
+                image_epsg = metadata[satname]['epsg'][i]
+                pts_coords = SDS_tools.convert_epsg(pts_sl, image_epsg, settings['output_epsg'])
+
+                # save the reference shoreline as .pkl
+                filepath = os.path.join(filepath_data, sitename)
+                with open(os.path.join(filepath, sitename + '_reference_shoreline.pkl'), 'wb') as f:
+                    pickle.dump(pts_coords, f)
+
+                # also store as .geojson in case user wants to drag-and-drop on GIS for verification
+                for k,line in enumerate(geoms):
+                    gdf = gpd.GeoDataFrame(geometry=gpd.GeoSeries(line))
+                    gdf.index = [k]
+                    gdf.loc[k,'name'] = 'reference shoreline ' + str(k+1)
+                    # store into geodataframe
+                    if k == 0:
+                        gdf_all = gdf
+                    else:
+                        gdf_all = gdf_all.append(gdf)
+                gdf_all.crs = {'init':'epsg:'+str(image_epsg)}
+                # convert from image_epsg to user-defined coordinate system
+                gdf_all = gdf_all.to_crs({'init': 'epsg:'+str(settings['output_epsg'])})
+                # save as geojson
+                gdf_all.to_file(os.path.join(filepath, sitename + '_reference_shoreline.geojson'),
+                                driver='GeoJSON', encoding='utf-8')
+
+                print('Reference shoreline has been saved in ' + filepath)
+                break
+            
+    # check if a shoreline was digitised
+    if len(pts_coords) == 0:
+        raise Exception('No cloud free images are available to digitise the reference shoreline,'+
+                        'download more images and try again') 
+
+    return pts_coords

--- a/notebooks/coastsat/SDS_shoreline.py
+++ b/notebooks/coastsat/SDS_shoreline.py
@@ -1,0 +1,1144 @@
+"""
+This module contains all the functions needed for extracting satellite-derived 
+shorelines (SDS)
+
+Author: Kilian Vos, Water Research Laboratory, University of New South Wales
+"""
+
+# load modules
+import os
+import numpy as np
+import matplotlib.pyplot as plt
+import pdb
+
+# image processing modules
+import skimage.filters as filters
+import skimage.measure as measure
+import skimage.morphology as morphology
+
+# machine learning modules
+import sklearn
+if sklearn.__version__[:4] == '0.20':
+    from sklearn.externals import joblib
+else:
+    import joblib
+from shapely.geometry import LineString
+
+# other modules
+import matplotlib.patches as mpatches
+import matplotlib.lines as mlines
+import matplotlib.cm as cm
+from matplotlib import gridspec
+import pickle
+from datetime import datetime
+from pylab import ginput
+
+# CoastSat modules
+from coastsat import SDS_tools, SDS_preprocess
+
+np.seterr(all='ignore') # raise/ignore divisions by 0 and nans
+
+# Main function for batch shoreline detection
+def extract_shorelines(metadata, settings):
+    """
+    Main function to extract shorelines from satellite images
+
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    metadata: dict
+        contains all the information about the satellite images that were downloaded
+    settings: dict with the following keys
+        'inputs': dict
+            input parameters (sitename, filepath, polygon, dates, sat_list)
+        'cloud_thresh': float
+            value between 0 and 1 indicating the maximum cloud fraction in 
+            the cropped image that is accepted
+        'cloud_mask_issue': boolean
+            True if there is an issue with the cloud mask and sand pixels
+            are erroneously being masked on the images
+        'buffer_size': int
+            size of the buffer (m) around the sandy pixels over which the pixels 
+            are considered in the thresholding algorithm
+        'min_beach_area': int
+            minimum allowable object area (in metres^2) for the class 'sand',
+            the area is converted to number of connected pixels
+        'min_length_sl': int
+            minimum length (in metres) of shoreline contour to be valid
+        'sand_color': str
+            default', 'dark' (for grey/black sand beaches) or 'bright' (for white sand beaches)
+        'output_epsg': int
+            output spatial reference system as EPSG code
+        'check_detection': bool
+            if True, lets user manually accept/reject the mapped shorelines
+        'save_figure': bool
+            if True, saves a -jpg file for each mapped shoreline
+        'adjust_detection': bool
+            if True, allows user to manually adjust the detected shoreline
+            
+    Returns:
+    -----------
+    output: dict
+        contains the extracted shorelines and corresponding dates + metadata
+
+    """
+
+    sitename = settings['inputs']['sitename']
+    filepath_data = settings['inputs']['filepath']
+    filepath_models = os.path.join(os.getcwd(), 'classification', 'models')
+    # initialise output structure
+    output = dict([])
+    # create a subfolder to store the .jpg images showing the detection
+    filepath_jpg = os.path.join(filepath_data, sitename, 'jpg_files', 'detection')
+    if not os.path.exists(filepath_jpg):
+            os.makedirs(filepath_jpg)
+    # close all open figures
+    plt.close('all')
+
+    print('Mapping shorelines:')
+
+    # loop through satellite list
+    for satname in metadata.keys():
+
+        # get images
+        filepath = SDS_tools.get_filepath(settings['inputs'],satname)
+        filenames = metadata[satname]['filenames']
+
+        # initialise the output variables
+        output_timestamp = []  # datetime at which the image was acquired (UTC time)
+        output_shoreline = []  # vector of shoreline points
+        output_filename = []   # filename of the images from which the shorelines where derived
+        output_cloudcover = [] # cloud cover of the images
+        output_geoaccuracy = []# georeferencing accuracy of the images
+        output_idxkeep = []    # index that were kept during the analysis (cloudy images are skipped)
+        output_t_mndwi = []    # MNDWI threshold used to map the shoreline
+        
+        # load classifiers (if sklearn version above 0.20, learn the new files)
+        str_new = ''
+        if not sklearn.__version__[:4] == '0.20':
+            str_new = '_new'
+        if satname in ['L5','L7','L8']:
+            pixel_size = 15
+            if settings['sand_color'] == 'dark':
+                clf = joblib.load(os.path.join(filepath_models, 'NN_4classes_Landsat_dark%s.pkl'%str_new))
+            elif settings['sand_color'] == 'bright':
+                clf = joblib.load(os.path.join(filepath_models, 'NN_4classes_Landsat_bright%s.pkl'%str_new))
+            else:
+                clf = joblib.load(os.path.join(filepath_models, 'NN_4classes_Landsat%s.pkl'%str_new))
+
+        elif satname == 'S2':
+            pixel_size = 10
+            clf = joblib.load(os.path.join(filepath_models, 'NN_4classes_S2%s.pkl'%str_new))
+
+        # convert settings['min_beach_area'] and settings['buffer_size'] from metres to pixels
+        buffer_size_pixels = np.ceil(settings['buffer_size']/pixel_size)
+        min_beach_area_pixels = np.ceil(settings['min_beach_area']/pixel_size**2)
+
+        # loop through the images
+        for i in range(len(filenames)):
+
+            print('\r%s:   %d%%' % (satname,int(((i+1)/len(filenames))*100)), end='')
+
+            # get image filename
+            fn = SDS_tools.get_filenames(filenames[i],filepath, satname)
+            # preprocess image (cloud mask + pansharpening/downsampling)
+            im_ms, georef, cloud_mask, im_extra, im_QA, im_nodata = SDS_preprocess.preprocess_single(fn, satname, settings['cloud_mask_issue'])
+            # get image spatial reference system (epsg code) from metadata dict
+            image_epsg = metadata[satname]['epsg'][i]
+            
+            # compute cloud_cover percentage (with no data pixels)
+            cloud_cover_combined = np.divide(sum(sum(cloud_mask.astype(int))),
+                                    (cloud_mask.shape[0]*cloud_mask.shape[1]))
+            if cloud_cover_combined > 0.99: # if 99% of cloudy pixels in image skip
+                continue
+            # remove no data pixels from the cloud mask 
+            # (for example L7 bands of no data should not be accounted for)
+            cloud_mask_adv = np.logical_xor(cloud_mask, im_nodata) 
+            # compute updated cloud cover percentage (without no data pixels)
+            cloud_cover = np.divide(sum(sum(cloud_mask_adv.astype(int))),
+                                    (sum(sum((~im_nodata).astype(int)))))
+            # skip image if cloud cover is above user-defined threshold
+            if cloud_cover > settings['cloud_thresh']:
+                continue
+
+            # calculate a buffer around the reference shoreline (if any has been digitised)
+            im_ref_buffer = create_shoreline_buffer(cloud_mask.shape, georef, image_epsg,
+                                                    pixel_size, settings)
+
+            # classify image in 4 classes (sand, whitewater, water, other) with NN classifier
+            im_classif, im_labels = classify_image_NN(im_ms, im_extra, cloud_mask,
+                                    min_beach_area_pixels, clf)
+            
+            # if adjust_detection is True, let the user adjust the detected shoreline
+            if settings['adjust_detection']:
+                date = filenames[i][:19]
+                skip_image, shoreline, t_mndwi = adjust_detection(im_ms, cloud_mask, im_labels,
+                                                                  im_ref_buffer, image_epsg, georef,
+                                                                  settings, date, satname, buffer_size_pixels)
+                # if the user decides to skip the image, continue and do not save the mapped shoreline
+                if skip_image:
+                    continue
+                
+            # otherwise map the contours automatically with one of the two following functions:
+            # if there are pixels in the 'sand' class --> use find_wl_contours2 (enhanced)
+            # otherwise use find_wl_contours2 (traditional)
+            else:
+                try: # use try/except structure for long runs
+                    if sum(sum(im_labels[:,:,0])) < 10 : # minimum number of sand pixels
+                        # compute MNDWI image (SWIR-G)
+                        im_mndwi = SDS_tools.nd_index(im_ms[:,:,4], im_ms[:,:,1], cloud_mask)
+                        # find water contours on MNDWI grayscale image
+                        contours_mwi, t_mndwi = find_wl_contours1(im_mndwi, cloud_mask, im_ref_buffer)
+                    else:
+                        # use classification to refine threshold and extract the sand/water interface
+                        contours_mwi, t_mndwi = find_wl_contours2(im_ms, im_labels, cloud_mask,
+                                                                  buffer_size_pixels, im_ref_buffer)
+                except:
+                    print('Could not map shoreline for this image: ' + filenames[i])
+                    continue
+    
+                # process the water contours into a shoreline
+                shoreline = process_shoreline(contours_mwi, cloud_mask, georef, image_epsg, settings)
+    
+                # visualise the mapped shorelines, there are two options:
+                # if settings['check_detection'] = True, shows the detection to the user for accept/reject
+                # if settings['save_figure'] = True, saves a figure for each mapped shoreline
+                if settings['check_detection'] or settings['save_figure']:
+                    date = filenames[i][:19]
+                    if not settings['check_detection']:
+                        plt.ioff() # turning interactive plotting off
+                    skip_image = show_detection(im_ms, cloud_mask, im_labels, shoreline,
+                                                image_epsg, georef, settings, date, satname)
+                    # if the user decides to skip the image, continue and do not save the mapped shoreline
+                    if skip_image:
+                        continue
+
+            # append to output variables
+            output_timestamp.append(metadata[satname]['dates'][i])
+            output_shoreline.append(shoreline)
+            output_filename.append(filenames[i])
+            output_cloudcover.append(cloud_cover)
+            output_geoaccuracy.append(metadata[satname]['acc_georef'][i])
+            output_idxkeep.append(i)
+            output_t_mndwi.append(t_mndwi)
+
+        # create dictionnary of output
+        output[satname] = {
+                'dates': output_timestamp,
+                'shorelines': output_shoreline,
+                'filename': output_filename,
+                'cloud_cover': output_cloudcover,
+                'geoaccuracy': output_geoaccuracy,
+                'idx': output_idxkeep,
+                'MNDWI_threshold': output_t_mndwi,
+                }
+        print('')
+
+    # close figure window if still open
+    if plt.get_fignums():
+        plt.close()
+
+    # change the format to have one list sorted by date with all the shorelines (easier to use)
+    output = SDS_tools.merge_output(output)
+
+    # save outputput structure as output.pkl
+    filepath = os.path.join(filepath_data, sitename)
+    with open(os.path.join(filepath, sitename + '_output.pkl'), 'wb') as f:
+        pickle.dump(output, f)
+
+    return output
+
+###################################################################################################
+# IMAGE CLASSIFICATION FUNCTIONS
+###################################################################################################
+
+def calculate_features(im_ms, cloud_mask, im_bool):
+    """
+    Calculates features on the image that are used for the supervised classification. 
+    The features include spectral normalized-difference indices and standard 
+    deviation of the image for all the bands and indices.
+
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    im_ms: np.array
+        RGB + downsampled NIR and SWIR
+    cloud_mask: np.array
+        2D cloud mask with True where cloud pixels are
+    im_bool: np.array
+        2D array of boolean indicating where on the image to calculate the features
+
+    Returns:    
+    -----------
+    features: np.array
+        matrix containing each feature (columns) calculated for all
+        the pixels (rows) indicated in im_bool
+        
+    """
+
+    # add all the multispectral bands
+    features = np.expand_dims(im_ms[im_bool,0],axis=1)
+    for k in range(1,im_ms.shape[2]):
+        feature = np.expand_dims(im_ms[im_bool,k],axis=1)
+        features = np.append(features, feature, axis=-1)
+    # NIR-G
+    im_NIRG = SDS_tools.nd_index(im_ms[:,:,3], im_ms[:,:,1], cloud_mask)
+    features = np.append(features, np.expand_dims(im_NIRG[im_bool],axis=1), axis=-1)
+    # SWIR-G
+    im_SWIRG = SDS_tools.nd_index(im_ms[:,:,4], im_ms[:,:,1], cloud_mask)
+    features = np.append(features, np.expand_dims(im_SWIRG[im_bool],axis=1), axis=-1)
+    # NIR-R
+    im_NIRR = SDS_tools.nd_index(im_ms[:,:,3], im_ms[:,:,2], cloud_mask)
+    features = np.append(features, np.expand_dims(im_NIRR[im_bool],axis=1), axis=-1)
+    # SWIR-NIR
+    im_SWIRNIR = SDS_tools.nd_index(im_ms[:,:,4], im_ms[:,:,3], cloud_mask)
+    features = np.append(features, np.expand_dims(im_SWIRNIR[im_bool],axis=1), axis=-1)
+    # B-R
+    im_BR = SDS_tools.nd_index(im_ms[:,:,0], im_ms[:,:,2], cloud_mask)
+    features = np.append(features, np.expand_dims(im_BR[im_bool],axis=1), axis=-1)
+    # calculate standard deviation of individual bands
+    for k in range(im_ms.shape[2]):
+        im_std =  SDS_tools.image_std(im_ms[:,:,k], 1)
+        features = np.append(features, np.expand_dims(im_std[im_bool],axis=1), axis=-1)
+    # calculate standard deviation of the spectral indices
+    im_std = SDS_tools.image_std(im_NIRG, 1)
+    features = np.append(features, np.expand_dims(im_std[im_bool],axis=1), axis=-1)
+    im_std = SDS_tools.image_std(im_SWIRG, 1)
+    features = np.append(features, np.expand_dims(im_std[im_bool],axis=1), axis=-1)
+    im_std = SDS_tools.image_std(im_NIRR, 1)
+    features = np.append(features, np.expand_dims(im_std[im_bool],axis=1), axis=-1)
+    im_std = SDS_tools.image_std(im_SWIRNIR, 1)
+    features = np.append(features, np.expand_dims(im_std[im_bool],axis=1), axis=-1)
+    im_std = SDS_tools.image_std(im_BR, 1)
+    features = np.append(features, np.expand_dims(im_std[im_bool],axis=1), axis=-1)
+
+    return features
+
+def classify_image_NN(im_ms, im_extra, cloud_mask, min_beach_area, clf):
+    """
+    Classifies every pixel in the image in one of 4 classes:
+        - sand                                          --> label = 1
+        - whitewater (breaking waves and swash)         --> label = 2
+        - water                                         --> label = 3
+        - other (vegetation, buildings, rocks...)       --> label = 0
+
+    The classifier is a Neural Network that is already trained.
+
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    im_ms: np.array
+        Pansharpened RGB + downsampled NIR and SWIR
+    im_extra:
+        only used for Landsat 7 and 8 where im_extra is the panchromatic band
+    cloud_mask: np.array
+        2D cloud mask with True where cloud pixels are
+    min_beach_area: int
+        minimum number of pixels that have to be connected to belong to the SAND class
+    clf: joblib object
+        pre-trained classifier
+
+    Returns:    
+    -----------
+    im_classif: np.array
+        2D image containing labels
+    im_labels: np.array of booleans
+        3D image containing a boolean image for each class (im_classif == label)
+
+    """
+
+    # calculate features
+    vec_features = calculate_features(im_ms, cloud_mask, np.ones(cloud_mask.shape).astype(bool))
+    vec_features[np.isnan(vec_features)] = 1e-9 # NaN values are create when std is too close to 0
+
+    # remove NaNs and cloudy pixels
+    vec_cloud = cloud_mask.reshape(cloud_mask.shape[0]*cloud_mask.shape[1])
+    vec_nan = np.any(np.isnan(vec_features), axis=1)
+    vec_inf = np.any(np.isinf(vec_features), axis=1)    
+    vec_mask = np.logical_or(vec_cloud,np.logical_or(vec_nan,vec_inf))
+    vec_features = vec_features[~vec_mask, :]
+
+    # classify pixels
+    labels = clf.predict(vec_features)
+
+    # recompose image
+    vec_classif = np.nan*np.ones((cloud_mask.shape[0]*cloud_mask.shape[1]))
+    vec_classif[~vec_mask] = labels
+    im_classif = vec_classif.reshape((cloud_mask.shape[0], cloud_mask.shape[1]))
+
+    # create a stack of boolean images for each label
+    im_sand = im_classif == 1
+    im_swash = im_classif == 2
+    im_water = im_classif == 3
+    # remove small patches of sand or water that could be around the image (usually noise)
+    im_sand = morphology.remove_small_objects(im_sand, min_size=min_beach_area, connectivity=2)
+    im_water = morphology.remove_small_objects(im_water, min_size=min_beach_area, connectivity=2)
+
+    im_labels = np.stack((im_sand,im_swash,im_water), axis=-1)
+
+    return im_classif, im_labels
+
+###################################################################################################
+# CONTOUR MAPPING FUNCTIONS
+###################################################################################################
+
+def find_wl_contours1(im_ndwi, cloud_mask, im_ref_buffer):
+    """
+    Traditional method for shoreline detection using a global threshold.
+    Finds the water line by thresholding the Normalized Difference Water Index 
+    and applying the Marching Squares Algorithm to contour the iso-value 
+    corresponding to the threshold.
+
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    im_ndwi: np.ndarray
+        Image (2D) with the NDWI (water index)
+    cloud_mask: np.ndarray
+        2D cloud mask with True where cloud pixels are
+    im_ref_buffer: np.array
+        Binary image containing a buffer around the reference shoreline
+
+    Returns:    
+    -----------
+    contours: list of np.arrays
+        contains the coordinates of the contour lines
+    t_mwi: float
+        Otsu threshold used to map the contours
+
+    """
+
+    # reshape image to vector
+    vec_ndwi = im_ndwi.reshape(im_ndwi.shape[0] * im_ndwi.shape[1])
+    vec_mask = cloud_mask.reshape(cloud_mask.shape[0] * cloud_mask.shape[1])
+    vec = vec_ndwi[~vec_mask]
+    # apply otsu's threshold
+    vec = vec[~np.isnan(vec)]
+    t_otsu = filters.threshold_otsu(vec)
+    # use Marching Squares algorithm to detect contours on ndwi image
+    im_ndwi_buffer = np.copy(im_ndwi)
+    im_ndwi_buffer[~im_ref_buffer] = np.nan
+    contours = measure.find_contours(im_ndwi_buffer, t_otsu)
+    # remove contours that contain NaNs (due to cloud pixels in the contour)
+    contours = process_contours(contours)
+
+    return contours, t_otsu
+
+def find_wl_contours2(im_ms, im_labels, cloud_mask, buffer_size, im_ref_buffer):
+    """
+    New robust method for extracting shorelines. Incorporates the classification
+    component to refine the treshold and make it specific to the sand/water interface.
+
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    im_ms: np.array
+        RGB + downsampled NIR and SWIR
+    im_labels: np.array
+        3D image containing a boolean image for each class in the order (sand, swash, water)
+    cloud_mask: np.array
+        2D cloud mask with True where cloud pixels are
+    buffer_size: int
+        size of the buffer around the sandy beach over which the pixels are considered in the
+        thresholding algorithm.
+    im_ref_buffer: np.array
+        binary image containing a buffer around the reference shoreline
+
+    Returns:    
+    -----------
+    contours_mwi: list of np.arrays
+        contains the coordinates of the contour lines extracted from the
+        MNDWI (Modified Normalized Difference Water Index) image
+    t_mwi: float
+        Otsu sand/water threshold used to map the contours
+
+    """
+
+    nrows = cloud_mask.shape[0]
+    ncols = cloud_mask.shape[1]
+
+    # calculate Normalized Difference Modified Water Index (SWIR - G)
+    im_mwi = SDS_tools.nd_index(im_ms[:,:,4], im_ms[:,:,1], cloud_mask)
+    # calculate Normalized Difference Modified Water Index (NIR - G)
+    im_wi = SDS_tools.nd_index(im_ms[:,:,3], im_ms[:,:,1], cloud_mask)
+    # stack indices together
+    im_ind = np.stack((im_wi, im_mwi), axis=-1)
+    vec_ind = im_ind.reshape(nrows*ncols,2)
+
+    # reshape labels into vectors
+    vec_sand = im_labels[:,:,0].reshape(ncols*nrows)
+    vec_water = im_labels[:,:,2].reshape(ncols*nrows)
+
+    # create a buffer around the sandy beach
+    se = morphology.disk(buffer_size)
+    im_buffer = morphology.binary_dilation(im_labels[:,:,0], se)
+    vec_buffer = im_buffer.reshape(nrows*ncols)
+
+    # select water/sand/swash pixels that are within the buffer
+    int_water = vec_ind[np.logical_and(vec_buffer,vec_water),:]
+    int_sand = vec_ind[np.logical_and(vec_buffer,vec_sand),:]
+
+    # make sure both classes have the same number of pixels before thresholding
+    if len(int_water) > 0 and len(int_sand) > 0:
+        if np.argmin([int_sand.shape[0],int_water.shape[0]]) == 1:
+            int_sand = int_sand[np.random.choice(int_sand.shape[0],int_water.shape[0], replace=False),:]
+        else:
+            int_water = int_water[np.random.choice(int_water.shape[0],int_sand.shape[0], replace=False),:]
+
+    # threshold the sand/water intensities
+    int_all = np.append(int_water,int_sand, axis=0)
+    t_mwi = filters.threshold_otsu(int_all[:,0])
+    t_wi = filters.threshold_otsu(int_all[:,1])
+
+    # find contour with MS algorithm
+    im_wi_buffer = np.copy(im_wi)
+    im_wi_buffer[~im_ref_buffer] = np.nan
+    im_mwi_buffer = np.copy(im_mwi)
+    im_mwi_buffer[~im_ref_buffer] = np.nan
+    contours_wi = measure.find_contours(im_wi_buffer, t_wi)
+    contours_mwi = measure.find_contours(im_mwi_buffer, t_mwi)
+    # remove contour points that are NaNs (around clouds)
+    contours_wi = process_contours(contours_wi)
+    contours_mwi = process_contours(contours_mwi)
+
+    # only return MNDWI contours and threshold
+    return contours_mwi, t_mwi
+
+###################################################################################################
+# SHORELINE PROCESSING FUNCTIONS
+###################################################################################################
+
+def create_shoreline_buffer(im_shape, georef, image_epsg, pixel_size, settings):
+    """
+    Creates a buffer around the reference shoreline. The size of the buffer is 
+    given by settings['max_dist_ref'].
+
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    im_shape: np.array
+        size of the image (rows,columns)
+    georef: np.array
+        vector of 6 elements [Xtr, Xscale, Xshear, Ytr, Yshear, Yscale]
+    image_epsg: int
+        spatial reference system of the image from which the contours were extracted
+    pixel_size: int
+        size of the pixel in metres (15 for Landsat, 10 for Sentinel-2)
+    settings: dict with the following keys
+        'output_epsg': int
+            output spatial reference system
+        'reference_shoreline': np.array
+            coordinates of the reference shoreline
+        'max_dist_ref': int
+            maximum distance from the reference shoreline in metres
+
+    Returns:    
+    -----------
+    im_buffer: np.array
+        binary image, True where the buffer is, False otherwise
+
+    """
+    # initialise the image buffer
+    im_buffer = np.ones(im_shape).astype(bool)
+
+    if 'reference_shoreline' in settings.keys():
+
+        # convert reference shoreline to pixel coordinates
+        ref_sl = settings['reference_shoreline']
+        ref_sl_conv = SDS_tools.convert_epsg(ref_sl, settings['output_epsg'],image_epsg)[:,:-1]
+        ref_sl_pix = SDS_tools.convert_world2pix(ref_sl_conv, georef)
+        ref_sl_pix_rounded = np.round(ref_sl_pix).astype(int)
+
+        # make sure that the pixel coordinates of the reference shoreline are inside the image
+        idx_row = np.logical_and(ref_sl_pix_rounded[:,0] > 0, ref_sl_pix_rounded[:,0] < im_shape[1])
+        idx_col = np.logical_and(ref_sl_pix_rounded[:,1] > 0, ref_sl_pix_rounded[:,1] < im_shape[0])
+        idx_inside = np.logical_and(idx_row, idx_col)
+        ref_sl_pix_rounded = ref_sl_pix_rounded[idx_inside,:]
+
+        # create binary image of the reference shoreline (1 where the shoreline is 0 otherwise)
+        im_binary = np.zeros(im_shape)
+        for j in range(len(ref_sl_pix_rounded)):
+            im_binary[ref_sl_pix_rounded[j,1], ref_sl_pix_rounded[j,0]] = 1
+        im_binary = im_binary.astype(bool)
+
+        # dilate the binary image to create a buffer around the reference shoreline
+        max_dist_ref_pixels = np.ceil(settings['max_dist_ref']/pixel_size)
+        se = morphology.disk(max_dist_ref_pixels)
+        im_buffer = morphology.binary_dilation(im_binary, se)
+
+    return im_buffer
+
+def process_contours(contours):
+    """
+    Remove contours that contain NaNs, usually these are contours that are in contact 
+    with clouds.
+    
+    KV WRL 2020
+    
+    Arguments:
+    -----------
+    contours: list of np.array
+        image contours as detected by the function skimage.measure.find_contours    
+    
+    Returns:
+    -----------
+    contours: list of np.array
+        processed image contours (only the ones that do not contains NaNs) 
+        
+    """
+    
+    # initialise variable
+    contours_nonans = []
+    # loop through contours and only keep the ones without NaNs
+    for k in range(len(contours)):
+        if np.any(np.isnan(contours[k])):
+            index_nan = np.where(np.isnan(contours[k]))[0]
+            contours_temp = np.delete(contours[k], index_nan, axis=0)
+            if len(contours_temp) > 1:
+                contours_nonans.append(contours_temp)
+        else:
+            contours_nonans.append(contours[k])
+    
+    return contours_nonans
+    
+def process_shoreline(contours, cloud_mask, georef, image_epsg, settings):
+    """
+    Converts the contours from image coordinates to world coordinates. 
+    This function also removes the contours that are too small to be a shoreline 
+    (based on the parameter settings['min_length_sl'])
+
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    contours: np.array or list of np.array
+        image contours as detected by the function find_contours
+    cloud_mask: np.array
+        2D cloud mask with True where cloud pixels are
+    georef: np.array
+        vector of 6 elements [Xtr, Xscale, Xshear, Ytr, Yshear, Yscale]
+    image_epsg: int
+        spatial reference system of the image from which the contours were extracted
+    settings: dict with the following keys
+        'output_epsg': int
+            output spatial reference system
+        'min_length_sl': float
+            minimum length of shoreline contour to be kept (in meters)
+
+    Returns:
+    -----------
+    shoreline: np.array
+        array of points with the X and Y coordinates of the shoreline
+
+    """
+
+    # convert pixel coordinates to world coordinates
+    contours_world = SDS_tools.convert_pix2world(contours, georef)
+    # convert world coordinates to desired spatial reference system
+    contours_epsg = SDS_tools.convert_epsg(contours_world, image_epsg, settings['output_epsg'])
+    # remove contours that have a perimeter < min_length_sl (provided in settings dict)
+    # this enables to remove the very small contours that do not correspond to the shoreline
+    contours_long = []
+    for l, wl in enumerate(contours_epsg):
+        coords = [(wl[k,0], wl[k,1]) for k in range(len(wl))]
+        a = LineString(coords) # shapely LineString structure
+        if a.length >= settings['min_length_sl']:
+            contours_long.append(wl)
+    # format points into np.array
+    x_points = np.array([])
+    y_points = np.array([])
+    for k in range(len(contours_long)):
+        x_points = np.append(x_points,contours_long[k][:,0])
+        y_points = np.append(y_points,contours_long[k][:,1])
+    contours_array = np.transpose(np.array([x_points,y_points]))
+
+    shoreline = contours_array
+
+    # now remove any shoreline points that are attached to cloud pixels
+    if sum(sum(cloud_mask)) > 0:
+        # get the coordinates of the cloud pixels
+        idx_cloud = np.where(cloud_mask)
+        idx_cloud = np.array([(idx_cloud[0][k], idx_cloud[1][k]) for k in range(len(idx_cloud[0]))])
+        # convert to world coordinates and same epsg as the shoreline points
+        coords_cloud = SDS_tools.convert_epsg(SDS_tools.convert_pix2world(idx_cloud, georef),
+                                               image_epsg, settings['output_epsg'])[:,:-1]
+        # only keep the shoreline points that are at least 30m from any cloud pixel
+        idx_keep = np.ones(len(shoreline)).astype(bool)
+        for k in range(len(shoreline)):
+            if np.any(np.linalg.norm(shoreline[k,:] - coords_cloud, axis=1) < 30):
+                idx_keep[k] = False
+        shoreline = shoreline[idx_keep]
+
+    return shoreline
+
+###################################################################################################
+# PLOTTING FUNCTIONS
+###################################################################################################
+
+def show_detection(im_ms, cloud_mask, im_labels, shoreline,image_epsg, georef,
+                   settings, date, satname):
+    """
+    Shows the detected shoreline to the user for visual quality control. 
+    The user can accept/reject the detected shorelines  by using keep/skip
+    buttons.
+
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    im_ms: np.array
+        RGB + downsampled NIR and SWIR
+    cloud_mask: np.array
+        2D cloud mask with True where cloud pixels are
+    im_labels: np.array
+        3D image containing a boolean image for each class in the order (sand, swash, water)
+    shoreline: np.array
+        array of points with the X and Y coordinates of the shoreline
+    image_epsg: int
+        spatial reference system of the image from which the contours were extracted
+    georef: np.array
+        vector of 6 elements [Xtr, Xscale, Xshear, Ytr, Yshear, Yscale]
+    date: string
+        date at which the image was taken
+    satname: string
+        indicates the satname (L5,L7,L8 or S2)
+    settings: dict with the following keys
+        'inputs': dict
+            input parameters (sitename, filepath, polygon, dates, sat_list)
+        'output_epsg': int
+            output spatial reference system as EPSG code
+        'check_detection': bool
+            if True, lets user manually accept/reject the mapped shorelines
+        'save_figure': bool
+            if True, saves a -jpg file for each mapped shoreline
+
+    Returns:
+    -----------
+    skip_image: boolean
+        True if the user wants to skip the image, False otherwise
+
+    """
+
+    sitename = settings['inputs']['sitename']
+    filepath_data = settings['inputs']['filepath']
+    # subfolder where the .jpg file is stored if the user accepts the shoreline detection
+    filepath = os.path.join(filepath_data, sitename, 'jpg_files', 'detection')
+
+    im_RGB = SDS_preprocess.rescale_image_intensity(im_ms[:,:,[2,1,0]], cloud_mask, 99.9)
+
+    # compute classified image
+    im_class = np.copy(im_RGB)
+    cmap = cm.get_cmap('tab20c')
+    colorpalette = cmap(np.arange(0,13,1))
+    colours = np.zeros((3,4))
+    colours[0,:] = colorpalette[5]
+    colours[1,:] = np.array([204/255,1,1,1])
+    colours[2,:] = np.array([0,91/255,1,1])
+    for k in range(0,im_labels.shape[2]):
+        im_class[im_labels[:,:,k],0] = colours[k,0]
+        im_class[im_labels[:,:,k],1] = colours[k,1]
+        im_class[im_labels[:,:,k],2] = colours[k,2]
+
+    # compute MNDWI grayscale image
+    im_mwi = SDS_tools.nd_index(im_ms[:,:,4], im_ms[:,:,1], cloud_mask)
+
+    # transform world coordinates of shoreline into pixel coordinates
+    # use try/except in case there are no coordinates to be transformed (shoreline = [])
+    try:
+        sl_pix = SDS_tools.convert_world2pix(SDS_tools.convert_epsg(shoreline,
+                                                                    settings['output_epsg'],
+                                                                    image_epsg)[:,[0,1]], georef)
+    except:
+        # if try fails, just add nan into the shoreline vector so the next parts can still run
+        sl_pix = np.array([[np.nan, np.nan],[np.nan, np.nan]])
+
+    if plt.get_fignums():
+            # get open figure if it exists
+            fig = plt.gcf()
+            ax1 = fig.axes[0]
+            ax2 = fig.axes[1]
+            ax3 = fig.axes[2]
+    else:
+        # else create a new figure
+        fig = plt.figure()
+        fig.set_size_inches([18, 9])
+        mng = plt.get_current_fig_manager()
+        mng.window.showMaximized()
+
+        # according to the image shape, decide whether it is better to have the images
+        # in vertical subplots or horizontal subplots
+        if im_RGB.shape[1] > 2.5*im_RGB.shape[0]:
+            # vertical subplots
+            gs = gridspec.GridSpec(3, 1)
+            gs.update(bottom=0.03, top=0.97, left=0.03, right=0.97)
+            ax1 = fig.add_subplot(gs[0,0])
+            ax2 = fig.add_subplot(gs[1,0], sharex=ax1, sharey=ax1)
+            ax3 = fig.add_subplot(gs[2,0], sharex=ax1, sharey=ax1)
+        else:
+            # horizontal subplots
+            gs = gridspec.GridSpec(1, 3)
+            gs.update(bottom=0.05, top=0.95, left=0.05, right=0.95)
+            ax1 = fig.add_subplot(gs[0,0])
+            ax2 = fig.add_subplot(gs[0,1], sharex=ax1, sharey=ax1)
+            ax3 = fig.add_subplot(gs[0,2], sharex=ax1, sharey=ax1)
+
+    # change the color of nans to either black (0.0) or white (1.0) or somewhere in between
+    nan_color = 1.0
+    im_RGB = np.where(np.isnan(im_RGB), nan_color, im_RGB)
+    im_class = np.where(np.isnan(im_class), 1.0, im_class)
+
+    # create image 1 (RGB)
+    ax1.imshow(im_RGB)
+    ax1.plot(sl_pix[:,0], sl_pix[:,1], 'k.', markersize=3)
+    ax1.axis('off')
+    ax1.set_title(sitename, fontweight='bold', fontsize=16)
+
+    # create image 2 (classification)
+    ax2.imshow(im_class)
+    ax2.plot(sl_pix[:,0], sl_pix[:,1], 'k.', markersize=3)
+    ax2.axis('off')
+    orange_patch = mpatches.Patch(color=colours[0,:], label='sand')
+    white_patch = mpatches.Patch(color=colours[1,:], label='whitewater')
+    blue_patch = mpatches.Patch(color=colours[2,:], label='water')
+    black_line = mlines.Line2D([],[],color='k',linestyle='-', label='shoreline')
+    ax2.legend(handles=[orange_patch,white_patch,blue_patch, black_line],
+               bbox_to_anchor=(1, 0.5), fontsize=10)
+    ax2.set_title(date, fontweight='bold', fontsize=16)
+
+    # create image 3 (MNDWI)
+    ax3.imshow(im_mwi, cmap='bwr')
+    ax3.plot(sl_pix[:,0], sl_pix[:,1], 'k.', markersize=3)
+    ax3.axis('off')
+    ax3.set_title(satname, fontweight='bold', fontsize=16)
+
+    # additional options
+    #    ax1.set_anchor('W')
+    #    ax2.set_anchor('W')
+    #    cb = plt.colorbar()
+    #    cb.ax.tick_params(labelsize=10)
+    #    cb.set_label('MNDWI values')
+    #    ax3.set_anchor('W')
+
+    # if check_detection is True, let user manually accept/reject the images
+    skip_image = False
+    if settings['check_detection']:
+
+        # set a key event to accept/reject the detections (see https://stackoverflow.com/a/15033071)
+        # this variable needs to be immuatable so we can access it after the keypress event
+        key_event = {}
+        def press(event):
+            # store what key was pressed in the dictionary
+            key_event['pressed'] = event.key
+        # let the user press a key, right arrow to keep the image, left arrow to skip it
+        # to break the loop the user can press 'escape'
+        while True:
+            btn_keep = plt.text(1.1, 0.9, 'keep ⇨', size=12, ha="right", va="top",
+                                transform=ax1.transAxes,
+                                bbox=dict(boxstyle="square", ec='k',fc='w'))
+            btn_skip = plt.text(-0.1, 0.9, '⇦ skip', size=12, ha="left", va="top",
+                                transform=ax1.transAxes,
+                                bbox=dict(boxstyle="square", ec='k',fc='w'))
+            btn_esc = plt.text(0.5, 0, '<esc> to quit', size=12, ha="center", va="top",
+                                transform=ax1.transAxes,
+                                bbox=dict(boxstyle="square", ec='k',fc='w'))
+            plt.draw()
+            fig.canvas.mpl_connect('key_press_event', press)
+            plt.waitforbuttonpress()
+            # after button is pressed, remove the buttons
+            btn_skip.remove()
+            btn_keep.remove()
+            btn_esc.remove()
+
+            # keep/skip image according to the pressed key, 'escape' to break the loop
+            if key_event.get('pressed') == 'right':
+                skip_image = False
+                break
+            elif key_event.get('pressed') == 'left':
+                skip_image = True
+                break
+            elif key_event.get('pressed') == 'escape':
+                plt.close()
+                raise StopIteration('User cancelled checking shoreline detection')
+            else:
+                plt.waitforbuttonpress()
+
+    # if save_figure is True, save a .jpg under /jpg_files/detection
+    if settings['save_figure'] and not skip_image:
+        fig.savefig(os.path.join(filepath, date + '_' + satname + '.jpg'), dpi=150)
+
+    # don't close the figure window, but remove all axes and settings, ready for next plot
+    for ax in fig.axes:
+        ax.clear()
+
+    return skip_image
+
+def adjust_detection(im_ms, cloud_mask, im_labels, im_ref_buffer, image_epsg, georef,
+                       settings, date, satname, buffer_size_pixels):
+    """
+    Advanced version of show detection where the user can adjust the detected 
+    shorelines with a slide bar.
+
+    KV WRL 2020
+
+    Arguments:
+    -----------
+    im_ms: np.array
+        RGB + downsampled NIR and SWIR
+    cloud_mask: np.array
+        2D cloud mask with True where cloud pixels are
+    im_labels: np.array
+        3D image containing a boolean image for each class in the order (sand, swash, water)
+    im_ref_buffer: np.array
+        Binary image containing a buffer around the reference shoreline
+    image_epsg: int
+        spatial reference system of the image from which the contours were extracted
+    georef: np.array
+        vector of 6 elements [Xtr, Xscale, Xshear, Ytr, Yshear, Yscale]
+    date: string
+        date at which the image was taken
+    satname: string
+        indicates the satname (L5,L7,L8 or S2)
+    buffer_size_pixels: int
+        buffer_size converted to number of pixels
+    settings: dict with the following keys
+        'inputs': dict
+            input parameters (sitename, filepath, polygon, dates, sat_list)
+        'output_epsg': int
+            output spatial reference system as EPSG code
+        'save_figure': bool
+            if True, saves a -jpg file for each mapped shoreline
+
+    Returns:
+    -----------
+    skip_image: boolean
+        True if the user wants to skip the image, False otherwise
+    shoreline: np.array
+        array of points with the X and Y coordinates of the shoreline 
+    t_mndwi: float
+        value of the MNDWI threshold used to map the shoreline
+
+    """
+
+    sitename = settings['inputs']['sitename']
+    filepath_data = settings['inputs']['filepath']
+    # subfolder where the .jpg file is stored if the user accepts the shoreline detection
+    filepath = os.path.join(filepath_data, sitename, 'jpg_files', 'detection')
+    # format date
+    date_str = datetime.strptime(date,'%Y-%m-%d-%H-%M-%S').strftime('%Y-%m-%d  %H:%M:%S')
+    im_RGB = SDS_preprocess.rescale_image_intensity(im_ms[:,:,[2,1,0]], cloud_mask, 99.9)
+
+    # compute classified image
+    im_class = np.copy(im_RGB)
+    cmap = cm.get_cmap('tab20c')
+    colorpalette = cmap(np.arange(0,13,1))
+    colours = np.zeros((3,4))
+    colours[0,:] = colorpalette[5]
+    colours[1,:] = np.array([204/255,1,1,1])
+    colours[2,:] = np.array([0,91/255,1,1])
+    for k in range(0,im_labels.shape[2]):
+        im_class[im_labels[:,:,k],0] = colours[k,0]
+        im_class[im_labels[:,:,k],1] = colours[k,1]
+        im_class[im_labels[:,:,k],2] = colours[k,2]
+
+    # compute MNDWI grayscale image
+    im_mndwi = SDS_tools.nd_index(im_ms[:,:,4], im_ms[:,:,1], cloud_mask)
+    # buffer MNDWI using reference shoreline
+    im_mndwi_buffer = np.copy(im_mndwi)
+    im_mndwi_buffer[~im_ref_buffer] = np.nan
+
+    # get MNDWI pixel intensity in each class (for histogram plot)
+    int_sand = im_mndwi[im_labels[:,:,0]]
+    int_ww = im_mndwi[im_labels[:,:,1]]
+    int_water = im_mndwi[im_labels[:,:,2]]
+    labels_other = np.logical_and(np.logical_and(~im_labels[:,:,0],~im_labels[:,:,1]),~im_labels[:,:,2])
+    int_other = im_mndwi[labels_other]
+    
+    # create figure
+    if plt.get_fignums():
+            # if it exists, open the figure 
+            fig = plt.gcf()
+            ax1 = fig.axes[0]
+            ax2 = fig.axes[1]
+            ax3 = fig.axes[2]
+            ax4 = fig.axes[3]      
+    else:
+        # else create a new figure
+        fig = plt.figure()
+        fig.set_size_inches([18, 9])
+        mng = plt.get_current_fig_manager()
+        mng.window.showMaximized()
+        gs = gridspec.GridSpec(2, 3, height_ratios=[4,1])
+        gs.update(bottom=0.05, top=0.95, left=0.03, right=0.97)
+        ax1 = fig.add_subplot(gs[0,0])
+        ax2 = fig.add_subplot(gs[0,1], sharex=ax1, sharey=ax1)
+        ax3 = fig.add_subplot(gs[0,2], sharex=ax1, sharey=ax1)
+        ax4 = fig.add_subplot(gs[1,:])
+    ##########################################################################
+    # to do: rotate image if too wide
+    ##########################################################################
+
+    # change the color of nans to either black (0.0) or white (1.0) or somewhere in between
+    nan_color = 1.0
+    im_RGB = np.where(np.isnan(im_RGB), nan_color, im_RGB)
+    im_class = np.where(np.isnan(im_class), 1.0, im_class)
+
+    # plot image 1 (RGB)
+    ax1.imshow(im_RGB)
+    ax1.axis('off')
+    ax1.set_title('%s - %s'%(sitename, satname), fontsize=12)
+
+    # plot image 2 (classification)
+    ax2.imshow(im_class)
+    ax2.axis('off')
+    orange_patch = mpatches.Patch(color=colours[0,:], label='sand')
+    white_patch = mpatches.Patch(color=colours[1,:], label='whitewater')
+    blue_patch = mpatches.Patch(color=colours[2,:], label='water')
+    black_line = mlines.Line2D([],[],color='k',linestyle='-', label='shoreline')
+    ax2.legend(handles=[orange_patch,white_patch,blue_patch, black_line],
+               bbox_to_anchor=(1.1, 0.5), fontsize=10)
+    ax2.set_title(date_str, fontsize=12)
+
+    # plot image 3 (MNDWI)
+    ax3.imshow(im_mndwi, cmap='bwr')
+    ax3.axis('off')
+    ax3.set_title('MNDWI', fontsize=12)
+    
+    # plot histogram of MNDWI values
+    binwidth = 0.01
+    ax4.set_facecolor('0.75')
+    ax4.yaxis.grid(color='w', linestyle='--', linewidth=0.5)
+    ax4.set(ylabel='PDF',yticklabels=[], xlim=[-1,1])
+    if len(int_sand) > 0 and sum(~np.isnan(int_sand)) > 0:
+        bins = np.arange(np.nanmin(int_sand), np.nanmax(int_sand) + binwidth, binwidth)
+        ax4.hist(int_sand, bins=bins, density=True, color=colours[0,:], label='sand')
+    if len(int_ww) > 0 and sum(~np.isnan(int_ww)) > 0:
+        bins = np.arange(np.nanmin(int_ww), np.nanmax(int_ww) + binwidth, binwidth)
+        ax4.hist(int_ww, bins=bins, density=True, color=colours[1,:], label='whitewater', alpha=0.75) 
+    if len(int_water) > 0 and sum(~np.isnan(int_water)) > 0:
+        bins = np.arange(np.nanmin(int_water), np.nanmax(int_water) + binwidth, binwidth)
+        ax4.hist(int_water, bins=bins, density=True, color=colours[2,:], label='water', alpha=0.75) 
+    if len(int_other) > 0 and sum(~np.isnan(int_other)) > 0:
+        bins = np.arange(np.nanmin(int_other), np.nanmax(int_other) + binwidth, binwidth)
+        ax4.hist(int_other, bins=bins, density=True, color='C4', label='other', alpha=0.5) 
+    
+    # automatically map the shoreline based on the classifier if enough sand pixels
+    try:
+        if sum(sum(im_labels[:,:,0])) > 10:
+            # use classification to refine threshold and extract the sand/water interface
+            contours_mndwi, t_mndwi = find_wl_contours2(im_ms, im_labels, cloud_mask,
+                                                        buffer_size_pixels, im_ref_buffer)
+        else:       
+            # find water contours on MNDWI grayscale image
+            contours_mndwi, t_mndwi = find_wl_contours1(im_mndwi, cloud_mask, im_ref_buffer)    
+    except:
+        print('Could not map shoreline so image was skipped')
+        # clear axes and return skip_image=True, so that image is skipped above
+        for ax in fig.axes:
+            ax.clear()
+        return True,[],[]
+
+    # process the water contours into a shoreline
+    shoreline = process_shoreline(contours_mndwi, cloud_mask, georef, image_epsg, settings)
+    # convert shoreline to pixels
+    if len(shoreline) > 0:
+        sl_pix = SDS_tools.convert_world2pix(SDS_tools.convert_epsg(shoreline,
+                                                                    settings['output_epsg'],
+                                                                    image_epsg)[:,[0,1]], georef)
+    else: sl_pix = np.array([[np.nan, np.nan],[np.nan, np.nan]])
+    # plot the shoreline on the images
+    sl_plot1 = ax1.plot(sl_pix[:,0], sl_pix[:,1], 'k.', markersize=3)
+    sl_plot2 = ax2.plot(sl_pix[:,0], sl_pix[:,1], 'k.', markersize=3)
+    sl_plot3 = ax3.plot(sl_pix[:,0], sl_pix[:,1], 'k.', markersize=3)
+    t_line = ax4.axvline(x=t_mndwi,ls='--', c='k', lw=1.5, label='threshold')
+    ax4.legend(loc=1)
+    plt.draw() # to update the plot
+    # adjust the threshold manually by letting the user change the threshold
+    ax4.set_title('Click on the plot below to change the location of the threhsold and adjust the shoreline detection. When finished, press <Enter>')
+    while True:  
+        # let the user click on the threshold plot
+        pt = ginput(n=1, show_clicks=True, timeout=-1)
+        # if a point was clicked
+        if len(pt) > 0: 
+            # if user clicked somewhere wrong and value is not between -1 and 1
+            if np.abs(pt[0][0]) >= 1: continue
+            # update the threshold value
+            t_mndwi = pt[0][0]
+            # update the plot
+            t_line.set_xdata([t_mndwi,t_mndwi])
+            # map contours with new threshold
+            contours = measure.find_contours(im_mndwi_buffer, t_mndwi)
+            # remove contours that contain NaNs (due to cloud pixels in the contour)
+            contours = process_contours(contours) 
+            # process the water contours into a shoreline
+            shoreline = process_shoreline(contours, cloud_mask, georef, image_epsg, settings)
+            # convert shoreline to pixels
+            if len(shoreline) > 0:
+                sl_pix = SDS_tools.convert_world2pix(SDS_tools.convert_epsg(shoreline,
+                                                                            settings['output_epsg'],
+                                                                            image_epsg)[:,[0,1]], georef)
+            else: sl_pix = np.array([[np.nan, np.nan],[np.nan, np.nan]])
+            # update the plotted shorelines
+            sl_plot1[0].set_data([sl_pix[:,0], sl_pix[:,1]])
+            sl_plot2[0].set_data([sl_pix[:,0], sl_pix[:,1]])
+            sl_plot3[0].set_data([sl_pix[:,0], sl_pix[:,1]])
+            fig.canvas.draw_idle()
+        else:
+            ax4.set_title('MNDWI pixel intensities and threshold')
+            break
+    
+    # let user manually accept/reject the image
+    skip_image = False
+    # set a key event to accept/reject the detections (see https://stackoverflow.com/a/15033071)
+    # this variable needs to be immuatable so we can access it after the keypress event
+    key_event = {}
+    def press(event):
+        # store what key was pressed in the dictionary
+        key_event['pressed'] = event.key
+    # let the user press a key, right arrow to keep the image, left arrow to skip it
+    # to break the loop the user can press 'escape'
+    while True:
+        btn_keep = plt.text(1.1, 0.9, 'keep ⇨', size=12, ha="right", va="top",
+                            transform=ax1.transAxes,
+                            bbox=dict(boxstyle="square", ec='k',fc='w'))
+        btn_skip = plt.text(-0.1, 0.9, '⇦ skip', size=12, ha="left", va="top",
+                            transform=ax1.transAxes,
+                            bbox=dict(boxstyle="square", ec='k',fc='w'))
+        btn_esc = plt.text(0.5, 0, '<esc> to quit', size=12, ha="center", va="top",
+                            transform=ax1.transAxes,
+                            bbox=dict(boxstyle="square", ec='k',fc='w'))
+        plt.draw()
+        fig.canvas.mpl_connect('key_press_event', press)
+        plt.waitforbuttonpress()
+        # after button is pressed, remove the buttons
+        btn_skip.remove()
+        btn_keep.remove()
+        btn_esc.remove()
+
+        # keep/skip image according to the pressed key, 'escape' to break the loop
+        if key_event.get('pressed') == 'right':
+            skip_image = False
+            break
+        elif key_event.get('pressed') == 'left':
+            skip_image = True
+            break
+        elif key_event.get('pressed') == 'escape':
+            plt.close()
+            raise StopIteration('User cancelled checking shoreline detection')
+        else:
+            plt.waitforbuttonpress()
+
+    # if save_figure is True, save a .jpg under /jpg_files/detection
+    if settings['save_figure'] and not skip_image:
+        fig.savefig(os.path.join(filepath, date + '_' + satname + '.jpg'), dpi=150)
+
+    # don't close the figure window, but remove all axes and settings, ready for next plot
+    for ax in fig.axes:
+        ax.clear()
+
+    return skip_image, shoreline, t_mndwi

--- a/notebooks/coastsat/SDS_tools.py
+++ b/notebooks/coastsat/SDS_tools.py
@@ -1,0 +1,751 @@
+"""
+This module contains utilities to work with satellite images
+    
+Author: Kilian Vos, Water Research Laboratory, University of New South Wales
+"""
+
+# load modules
+import os
+import numpy as np
+import matplotlib.pyplot as plt
+import pdb
+
+# other modules
+from osgeo import gdal, osr
+import geopandas as gpd
+from shapely import geometry
+import skimage.transform as transform
+from astropy.convolution import convolve
+
+np.seterr(all='ignore') # raise/ignore divisions by 0 and nans
+
+###################################################################################################
+# COORDINATES CONVERSION FUNCTIONS
+###################################################################################################
+
+def convert_pix2world(points, georef):
+    """
+    Converts pixel coordinates (pixel row and column) to world projected 
+    coordinates performing an affine transformation.
+    
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    points: np.array or list of np.array
+        array with 2 columns (row first and column second)
+    georef: np.array
+        vector of 6 elements [Xtr, Xscale, Xshear, Ytr, Yshear, Yscale]
+                
+    Returns:    
+    -----------
+    points_converted: np.array or list of np.array 
+        converted coordinates, first columns with X and second column with Y
+        
+    """
+    
+    # make affine transformation matrix
+    aff_mat = np.array([[georef[1], georef[2], georef[0]],
+                       [georef[4], georef[5], georef[3]],
+                       [0, 0, 1]])
+    # create affine transformation
+    tform = transform.AffineTransform(aff_mat)
+
+    # if list of arrays
+    if type(points) is list:
+        points_converted = []
+        # iterate over the list
+        for i, arr in enumerate(points): 
+            tmp = arr[:,[1,0]]
+            points_converted.append(tform(tmp))
+          
+    # if single array
+    elif type(points) is np.ndarray:
+        tmp = points[:,[1,0]]
+        points_converted = tform(tmp)
+        
+    else:
+        raise Exception('invalid input type')
+        
+    return points_converted
+
+def convert_world2pix(points, georef):
+    """
+    Converts world projected coordinates (X,Y) to image coordinates 
+    (pixel row and column) performing an affine transformation.
+    
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    points: np.array or list of np.array
+        array with 2 columns (X,Y)
+    georef: np.array
+        vector of 6 elements [Xtr, Xscale, Xshear, Ytr, Yshear, Yscale]
+                
+    Returns:    
+    -----------
+    points_converted: np.array or list of np.array 
+        converted coordinates (pixel row and column)
+    
+    """
+    
+    # make affine transformation matrix
+    aff_mat = np.array([[georef[1], georef[2], georef[0]],
+                       [georef[4], georef[5], georef[3]],
+                       [0, 0, 1]])
+    # create affine transformation
+    tform = transform.AffineTransform(aff_mat)
+    
+    # if list of arrays
+    if type(points) is list:
+        points_converted = []
+        # iterate over the list
+        for i, arr in enumerate(points): 
+            points_converted.append(tform.inverse(points))
+            
+    # if single array    
+    elif type(points) is np.ndarray:
+        points_converted = tform.inverse(points)
+        
+    else:
+        print('invalid input type')
+        raise
+        
+    return points_converted
+
+
+def convert_epsg(points, epsg_in, epsg_out):
+    """
+    Converts from one spatial reference to another using the epsg codes
+    
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    points: np.array or list of np.ndarray
+        array with 2 columns (rows first and columns second)
+    epsg_in: int
+        epsg code of the spatial reference in which the input is
+    epsg_out: int
+        epsg code of the spatial reference in which the output will be            
+                
+    Returns:    
+    -----------
+    points_converted: np.array or list of np.array 
+        converted coordinates from epsg_in to epsg_out
+        
+    """
+    
+    # define input and output spatial references
+    inSpatialRef = osr.SpatialReference()
+    inSpatialRef.ImportFromEPSG(epsg_in)
+    outSpatialRef = osr.SpatialReference()
+    outSpatialRef.ImportFromEPSG(epsg_out)
+    # create a coordinates transform
+    coordTransform = osr.CoordinateTransformation(inSpatialRef, outSpatialRef)
+    # if list of arrays
+    if type(points) is list:
+        points_converted = []
+        # iterate over the list
+        for i, arr in enumerate(points): 
+            points_converted.append(np.array(coordTransform.TransformPoints(arr)))
+    # if single array
+    elif type(points) is np.ndarray:
+        points_converted = np.array(coordTransform.TransformPoints(points))  
+    else:
+        raise Exception('invalid input type')
+
+    return points_converted
+
+###################################################################################################
+# IMAGE ANALYSIS FUNCTIONS
+###################################################################################################
+    
+def nd_index(im1, im2, cloud_mask):
+    """
+    Computes normalised difference index on 2 images (2D), given a cloud mask (2D).
+
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    im1: np.array
+        first image (2D) with which to calculate the ND index
+    im2: np.array
+        second image (2D) with which to calculate the ND index
+    cloud_mask: np.array
+        2D cloud mask with True where cloud pixels are
+
+    Returns:    
+    -----------
+    im_nd: np.array
+        Image (2D) containing the ND index
+        
+    """
+
+    # reshape the cloud mask
+    vec_mask = cloud_mask.reshape(im1.shape[0] * im1.shape[1])
+    # initialise with NaNs
+    vec_nd = np.ones(len(vec_mask)) * np.nan
+    # reshape the two images
+    vec1 = im1.reshape(im1.shape[0] * im1.shape[1])
+    vec2 = im2.reshape(im2.shape[0] * im2.shape[1])
+    # compute the normalised difference index
+    temp = np.divide(vec1[~vec_mask] - vec2[~vec_mask],
+                     vec1[~vec_mask] + vec2[~vec_mask])
+    vec_nd[~vec_mask] = temp
+    # reshape into image
+    im_nd = vec_nd.reshape(im1.shape[0], im1.shape[1])
+
+    return im_nd
+    
+def image_std(image, radius):
+    """
+    Calculates the standard deviation of an image, using a moving window of 
+    specified radius. Uses astropy's convolution library'
+    
+    Arguments:
+    -----------
+    image: np.array
+        2D array containing the pixel intensities of a single-band image
+    radius: int
+        radius defining the moving window used to calculate the standard deviation. 
+        For example, radius = 1 will produce a 3x3 moving window.
+        
+    Returns:    
+    -----------
+    win_std: np.array
+        2D array containing the standard deviation of the image
+        
+    """  
+    
+    # convert to float
+    image = image.astype(float)
+    # first pad the image
+    image_padded = np.pad(image, radius, 'reflect')
+    # window size
+    win_rows, win_cols = radius*2 + 1, radius*2 + 1
+    # calculate std with uniform filters
+    win_mean = convolve(image_padded, np.ones((win_rows,win_cols)), boundary='extend',
+                        normalize_kernel=True, nan_treatment='interpolate', preserve_nan=True)
+    win_sqr_mean = convolve(image_padded**2, np.ones((win_rows,win_cols)), boundary='extend',
+                        normalize_kernel=True, nan_treatment='interpolate', preserve_nan=True)
+    win_var = win_sqr_mean - win_mean**2
+    win_std = np.sqrt(win_var)
+    # remove padding
+    win_std = win_std[radius:-radius, radius:-radius]
+
+    return win_std
+
+def mask_raster(fn, mask):
+    """
+    Masks a .tif raster using GDAL.
+    
+    Arguments:
+    -----------
+    fn: str
+        filepath + filename of the .tif raster
+    mask: np.array
+        array of boolean where True indicates the pixels that are to be masked
+        
+    Returns:    
+    -----------
+    Overwrites the .tif file directly
+        
+    """ 
+    
+    # open raster
+    raster = gdal.Open(fn, gdal.GA_Update)
+    # mask raster
+    for i in range(raster.RasterCount):
+        out_band = raster.GetRasterBand(i+1)
+        out_data = out_band.ReadAsArray()
+        out_band.SetNoDataValue(0)
+        no_data_value = out_band.GetNoDataValue()
+        out_data[mask] = no_data_value
+        out_band.WriteArray(out_data)
+    # close dataset and flush cache
+    raster = None
+
+
+###################################################################################################
+# UTILITIES
+###################################################################################################
+    
+def get_filepath(inputs,satname):
+    """
+    Create filepath to the different folders containing the satellite images.
+    
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    inputs: dict with the following keys
+        'sitename': str
+            name of the site
+        'polygon': list
+            polygon containing the lon/lat coordinates to be extracted,
+            longitudes in the first column and latitudes in the second column,
+            there are 5 pairs of lat/lon with the fifth point equal to the first point:
+            ```
+            polygon = [[[151.3, -33.7],[151.4, -33.7],[151.4, -33.8],[151.3, -33.8],
+            [151.3, -33.7]]]
+            ```
+        'dates': list of str
+            list that contains 2 strings with the initial and final dates in 
+            format 'yyyy-mm-dd':
+            ```
+            dates = ['1987-01-01', '2018-01-01']
+            ```
+        'sat_list': list of str
+            list that contains the names of the satellite missions to include: 
+            ```
+            sat_list = ['L5', 'L7', 'L8', 'S2']
+            ```
+        'filepath_data': str
+            filepath to the directory where the images are downloaded
+    satname: str
+        short name of the satellite mission ('L5','L7','L8','S2')
+                
+    Returns:    
+    -----------
+    filepath: str or list of str
+        contains the filepath(s) to the folder(s) containing the satellite images
+    
+    """     
+    
+    sitename = inputs['sitename']
+    filepath_data = inputs['filepath']
+    # access the images
+    if satname == 'L5':
+        # access downloaded Landsat 5 images
+        filepath = os.path.join(filepath_data, sitename, satname, '30m')
+    elif satname == 'L7':
+        # access downloaded Landsat 7 images
+        filepath_pan = os.path.join(filepath_data, sitename, 'L7', 'pan')
+        filepath_ms = os.path.join(filepath_data, sitename, 'L7', 'ms')
+        filepath = [filepath_pan, filepath_ms]
+    elif satname == 'L8':
+        # access downloaded Landsat 8 images
+        filepath_pan = os.path.join(filepath_data, sitename, 'L8', 'pan')
+        filepath_ms = os.path.join(filepath_data, sitename, 'L8', 'ms')
+        filepath = [filepath_pan, filepath_ms]
+    elif satname == 'S2':
+        # access downloaded Sentinel 2 images
+        filepath10 = os.path.join(filepath_data, sitename, satname, '10m')
+        filepath20 = os.path.join(filepath_data, sitename, satname, '20m')
+        filepath60 = os.path.join(filepath_data, sitename, satname, '60m')
+        filepath = [filepath10, filepath20, filepath60]
+            
+    return filepath
+    
+def get_filenames(filename, filepath, satname):
+    """
+    Creates filepath + filename for all the bands belonging to the same image.
+    
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    filename: str
+        name of the downloaded satellite image as found in the metadata
+    filepath: str or list of str
+        contains the filepath(s) to the folder(s) containing the satellite images
+    satname: str
+        short name of the satellite mission       
+        
+    Returns:    
+    -----------
+    fn: str or list of str
+        contains the filepath + filenames to access the satellite image
+        
+    """     
+    
+    if satname == 'L5':
+        fn = os.path.join(filepath, filename)
+    if satname == 'L7' or satname == 'L8':
+        filename_ms = filename.replace('pan','ms')
+        fn = [os.path.join(filepath[0], filename),
+              os.path.join(filepath[1], filename_ms)]
+    if satname == 'S2':
+        filename20 = filename.replace('10m','20m')
+        filename60 = filename.replace('10m','60m')
+        fn = [os.path.join(filepath[0], filename),
+              os.path.join(filepath[1], filename20),
+              os.path.join(filepath[2], filename60)]
+        
+    return fn
+
+def merge_output(output):
+    """
+    Function to merge the output dictionnary, which has one key per satellite mission
+    into a dictionnary containing all the shorelines and dates ordered chronologically.
+    
+    Arguments:
+    -----------
+    output: dict
+        contains the extracted shorelines and corresponding dates, organised by 
+        satellite mission
+    
+    Returns:    
+    -----------
+    output_all: dict
+        contains the extracted shorelines in a single list sorted by date
+    
+    """     
+    
+    # initialize output dict
+    output_all = dict([])
+    satnames = list(output.keys())
+    for key in output[satnames[0]].keys():
+        output_all[key] = []
+    # create extra key for the satellite name
+    output_all['satname'] = []
+    # fill the output dict
+    for satname in list(output.keys()):
+        for key in output[satnames[0]].keys():
+            output_all[key] = output_all[key] + output[satname][key]
+        output_all['satname'] = output_all['satname'] + [_ for _ in np.tile(satname,
+                  len(output[satname]['dates']))]
+    # sort chronologically
+    idx_sorted = sorted(range(len(output_all['dates'])), key=output_all['dates'].__getitem__)
+    for key in output_all.keys():
+        output_all[key] = [output_all[key][i] for i in idx_sorted]
+
+    return output_all
+
+
+def remove_duplicates(output):
+    """
+    Function to remove from the output dictionnary entries containing shorelines for 
+    the same date and satellite mission. This happens when there is an overlap between 
+    adjacent satellite images.
+
+    Arguments:
+    -----------
+        output: dict
+            contains output dict with shoreline and metadata
+
+    Returns:
+    -----------
+        output_no_duplicates: dict
+            contains the updated dict where duplicates have been removed
+
+    """
+
+    # nested function
+    def duplicates_dict(lst):
+        "return duplicates and indices"
+        def duplicates(lst, item):
+                return [i for i, x in enumerate(lst) if x == item]
+        return dict((x, duplicates(lst, x)) for x in set(lst) if lst.count(x) > 1)
+
+    dates = output['dates']
+    # make a list with year/month/day
+    dates_str = [_.strftime('%Y%m%d') for _ in dates]
+    # create a dictionnary with the duplicates
+    dupl = duplicates_dict(dates_str)
+    # if there are duplicates, only keep the first element
+    if dupl:
+        output_no_duplicates = dict([])
+        idx_remove = []
+        for k,v in dupl.items():
+            idx_remove.append(v[0])
+        idx_remove = sorted(idx_remove)
+        idx_all = np.linspace(0, len(dates_str)-1, len(dates_str))
+        idx_keep = list(np.where(~np.isin(idx_all,idx_remove))[0])
+        for key in output.keys():
+            output_no_duplicates[key] = [output[key][i] for i in idx_keep]
+        print('%d duplicates' % len(idx_remove))
+        return output_no_duplicates
+    else:
+        print('0 duplicates')
+        return output
+
+def remove_inaccurate_georef(output, accuracy):
+    """
+    Function to remove from the output dictionnary entries containing shorelines 
+    that were mapped on images with inaccurate georeferencing:
+        - RMSE > accuracy for Landsat images
+        - failed geometric test for Sentinel images (flagged with -1)
+
+    Arguments:
+    -----------
+        output: dict
+            contains the extracted shorelines and corresponding metadata
+        accuracy: int
+            minimum horizontal georeferencing accuracy (metres) for a shoreline to be accepted
+
+    Returns:
+    -----------
+        output_filtered: dict
+            contains the updated dictionnary
+
+    """
+
+    # find indices of shorelines to be removed
+    idx = np.where(~np.logical_or(np.array(output['geoaccuracy']) == -1,
+                                  np.array(output['geoaccuracy']) >= accuracy))[0]
+    # idx = np.where(~(np.array(output['geoaccuracy']) >= accuracy))[0]
+    output_filtered = dict([])
+    for key in output.keys():
+        output_filtered[key] = [output[key][i] for i in idx]
+    print('%d bad georef' % (len(output['geoaccuracy']) - len(idx)))
+    return output_filtered
+
+def get_closest_datapoint(dates, dates_ts, values_ts):
+    """
+    Extremely efficient script to get closest data point to a set of dates from a very
+    long time-series (e.g., 15-minutes tide data, or hourly wave data)
+    
+    Make sure that dates and dates_ts are in the same timezone (also aware or naive)
+    
+    KV WRL 2020
+
+    Arguments:
+    -----------
+    dates: list of datetimes
+        dates at which the closest point from the time-series should be extracted
+    dates_ts: list of datetimes
+        dates of the long time-series
+    values_ts: np.array
+        array with the values of the long time-series (tides, waves, etc...)
+        
+    Returns:    
+    -----------
+    values: np.array
+        values corresponding to the input dates
+        
+    """
+    
+    # check if the time-series cover the dates
+    if dates[0] < dates_ts[0] or dates[-1] > dates_ts[-1]: 
+        raise Exception('Time-series do not cover the range of your input dates')
+    
+    # get closest point to each date (no interpolation)
+    temp = []
+    def find(item, lst):
+        start = 0
+        start = lst.index(item, start)
+        return start
+    for i,date in enumerate(dates):
+        print('\rExtracting closest points: %d%%' % int((i+1)*100/len(dates)), end='')
+        temp.append(values_ts[find(min(item for item in dates_ts if item > date), dates_ts)])
+    values = np.array(temp)
+    
+    return values
+
+###################################################################################################
+# CONVERSIONS FROM DICT TO GEODATAFRAME AND READ/WRITE GEOJSON
+###################################################################################################
+    
+def polygon_from_kml(fn):
+    """
+    Extracts coordinates from a .kml file.
+    
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    fn: str
+        filepath + filename of the kml file to be read          
+                
+    Returns:    
+    -----------
+    polygon: list
+        coordinates extracted from the .kml file
+        
+    """    
+    
+    # read .kml file
+    with open(fn) as kmlFile:
+        doc = kmlFile.read() 
+    # parse to find coordinates field
+    str1 = '<coordinates>'
+    str2 = '</coordinates>'
+    subdoc = doc[doc.find(str1)+len(str1):doc.find(str2)]
+    coordlist = subdoc.split('\n')
+    # read coordinates
+    polygon = []
+    for i in range(1,len(coordlist)-1):
+        polygon.append([float(coordlist[i].split(',')[0]), float(coordlist[i].split(',')[1])])
+        
+    return [polygon]
+
+def transects_from_geojson(filename):
+    """
+    Reads transect coordinates from a .geojson file.
+    
+    Arguments:
+    -----------
+    filename: str
+        contains the path and filename of the geojson file to be loaded
+        
+    Returns:    
+    -----------
+    transects: dict
+        contains the X and Y coordinates of each transect
+        
+    """  
+    
+    gdf = gpd.read_file(filename)
+    transects = dict([])
+    for i in gdf.index:
+        transects[gdf.loc[i,'name']] = np.array(gdf.loc[i,'geometry'].coords)
+        
+    print('%d transects have been loaded' % len(transects.keys()))
+
+    return transects
+
+def output_to_gdf(output, geomtype):
+    """
+    Saves the mapped shorelines as a gpd.GeoDataFrame    
+    
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    output: dict
+        contains the coordinates of the mapped shorelines + attributes
+    geomtype: str
+        'lines' for LineString and 'points' for Multipoint geometry      
+                
+    Returns:    
+    -----------
+    gdf_all: gpd.GeoDataFrame
+        contains the shorelines + attirbutes
+  
+    """    
+     
+    # loop through the mapped shorelines
+    counter = 0
+    for i in range(len(output['shorelines'])):
+        # skip if there shoreline is empty 
+        if len(output['shorelines'][i]) == 0:
+            continue
+        else:
+            # save the geometry depending on the linestyle
+            if geomtype == 'lines':
+                geom = geometry.LineString(output['shorelines'][i])
+            elif geomtype == 'points':
+                coords = output['shorelines'][i]
+                geom = geometry.MultiPoint([(coords[_,0], coords[_,1]) for _ in range(coords.shape[0])])
+            else:
+                raise Exception('geomtype %s is not an option, choose between lines or points'%geomtype)
+            # save into geodataframe with attributes
+            gdf = gpd.GeoDataFrame(geometry=gpd.GeoSeries(geom))
+            gdf.index = [i]
+            gdf.loc[i,'date'] = output['dates'][i].strftime('%Y-%m-%d %H:%M:%S')
+            gdf.loc[i,'satname'] = output['satname'][i]
+            gdf.loc[i,'geoaccuracy'] = output['geoaccuracy'][i]
+            gdf.loc[i,'cloud_cover'] = output['cloud_cover'][i]
+            # store into geodataframe
+            if counter == 0:
+                gdf_all = gdf
+            else:
+                gdf_all = gdf_all.append(gdf)
+            counter = counter + 1
+            
+    return gdf_all
+
+def transects_to_gdf(transects):
+    """
+    Saves the shore-normal transects as a gpd.GeoDataFrame    
+    
+    KV WRL 2018
+
+    Arguments:
+    -----------
+    transects: dict
+        contains the coordinates of the transects          
+                
+    Returns:    
+    -----------
+    gdf_all: gpd.GeoDataFrame
+
+        
+    """  
+       
+    # loop through the mapped shorelines
+    for i,key in enumerate(list(transects.keys())):
+        # save the geometry + attributes
+        geom = geometry.LineString(transects[key])
+        gdf = gpd.GeoDataFrame(geometry=gpd.GeoSeries(geom))
+        gdf.index = [i]
+        gdf.loc[i,'name'] = key
+        # store into geodataframe
+        if i == 0:
+            gdf_all = gdf
+        else:
+            gdf_all = gdf_all.append(gdf)
+            
+    return gdf_all
+
+def get_image_bounds(fn):
+    """
+    Returns a polygon with the bounds of the image in the .tif file
+     
+    KV WRL 2020
+
+    Arguments:
+    -----------
+    fn: str
+        path to the image (.tif file)         
+                
+    Returns:    
+    -----------
+    bounds_polygon: shapely.geometry.Polygon
+        polygon with the image bounds
+        
+    """
+    
+    # nested functions to get the extent 
+    # copied from https://gis.stackexchange.com/questions/57834/how-to-get-raster-corner-coordinates-using-python-gdal-bindings
+    def GetExtent(gt,cols,rows):
+        'Return list of corner coordinates from a geotransform'
+        ext=[]
+        xarr=[0,cols]
+        yarr=[0,rows]
+        for px in xarr:
+            for py in yarr:
+                x=gt[0]+(px*gt[1])+(py*gt[2])
+                y=gt[3]+(px*gt[4])+(py*gt[5])
+                ext.append([x,y])
+            yarr.reverse()
+        return ext
+    
+    # load .tif file and get bounds
+    data = gdal.Open(fn, gdal.GA_ReadOnly)
+    gt = data.GetGeoTransform()
+    cols = data.RasterXSize
+    rows = data.RasterYSize
+    ext = GetExtent(gt,cols,rows)
+    
+    return geometry.Polygon(ext)
+
+def smallest_rectangle(polygon):
+    """
+    Converts a polygon to the smallest rectangle polygon with sides parallel
+    to coordinate axes.
+     
+    KV WRL 2020
+
+    Arguments:
+    -----------
+    polygon: list of coordinates 
+        pair of coordinates for 5 vertices, in clockwise order,
+        first and last points must match     
+                
+    Returns:    
+    -----------
+    polygon: list of coordinates
+        smallest rectangle polygon
+        
+    """
+    
+    multipoints = geometry.Polygon(polygon[0])
+    polygon_geom = multipoints.envelope
+    coords_polygon = np.array(polygon_geom.exterior.coords)
+    polygon_rect = [[[_[0], _[1]] for _ in coords_polygon]]
+    return polygon_rect

--- a/notebooks/coastsat/SDS_transects.py
+++ b/notebooks/coastsat/SDS_transects.py
@@ -1,0 +1,242 @@
+"""
+This module contains functions to analyze the 2D shorelines along shore-normal
+transects
+    
+Author: Kilian Vos, Water Research Laboratory, University of New South Wales
+"""
+
+# load modules
+import os
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+import pdb
+
+# other modules
+import skimage.transform as transform
+from pylab import ginput
+
+# CoastSat modules
+from coastsat import SDS_tools
+
+def create_transect(origin, orientation, length):
+    """
+    Create a transect given an origin, orientation and length.
+    Points are spaced at 1m intervals.
+    
+    KV WRL 2018
+    
+    Arguments:
+    -----------
+    origin: np.array
+        contains the X and Y coordinates of the origin of the transect
+    orientation: int
+        angle of the transect (anti-clockwise from North) in degrees
+    length: int
+        length of the transect in metres
+        
+    Returns:    
+    -----------
+    transect: np.array
+        contains the X and Y coordinates of the transect
+        
+    """   
+    
+    # origin of the transect
+    x0 = origin[0]
+    y0 = origin[1]
+    # orientation of the transect
+    phi = (90 - orientation)*np.pi/180 
+    # create a vector with points at 1 m intervals
+    x = np.linspace(0,length,length+1)
+    y = np.zeros(len(x))
+    coords = np.zeros((len(x),2))
+    coords[:,0] = x
+    coords[:,1] = y 
+    # translate and rotate the vector using the origin and orientation
+    tf = transform.EuclideanTransform(rotation=phi, translation=(x0,y0))
+    transect = tf(coords)
+                
+    return transect
+
+def draw_transects(output, settings):
+    """
+    Draw shore-normal transects interactively on top of the mapped shorelines
+
+    KV WRL 2018       
+
+    Arguments:
+    -----------
+    output: dict
+        contains the extracted shorelines and corresponding metadata
+    settings: dict with the following keys
+        'inputs': dict
+            input parameters (sitename, filepath, polygon, dates, sat_list)
+            
+    Returns:    
+    -----------
+    transects: dict
+        contains the X and Y coordinates of all the transects drawn.
+        Also saves the coordinates as a .geojson as well as a .jpg figure 
+        showing the location of the transects.       
+    """   
+    
+    sitename = settings['inputs']['sitename']
+    filepath = os.path.join(settings['inputs']['filepath'], sitename)
+
+    # plot the mapped shorelines
+    fig1 = plt.figure()
+    ax1 = fig1.add_subplot(111)
+    ax1.axis('equal')
+    ax1.set_xlabel('Eastings [m]')
+    ax1.set_ylabel('Northings [m]')
+    ax1.grid(linestyle=':', color='0.5')
+    for i in range(len(output['shorelines'])):
+        sl = output['shorelines'][i]
+        date = output['dates'][i]
+        ax1.plot(sl[:, 0], sl[:, 1], '.', markersize=3, label=date.strftime('%d-%m-%Y'))
+#    ax1.legend()
+    fig1.set_tight_layout(True)
+    mng = plt.get_current_fig_manager()                                         
+    mng.window.showMaximized()
+    ax1.set_title('Click two points to define each transect (first point is the ' +
+                  'origin of the transect and is landwards, second point seawards).\n'+
+                  'When all transects have been defined, click on <ENTER>', fontsize=16)
+    
+    # initialise transects dict
+    transects = dict([])
+    counter = 0
+    # loop until user breaks it by click <enter>
+    while 1:
+        # let user click two points
+        pts = ginput(n=2, timeout=-1)
+        if len(pts) > 0:
+            origin = pts[0]
+        # if user presses <enter>, no points are selected
+        else:
+            # save figure as .jpg
+            fig1.gca().set_title('Transect locations', fontsize=16)
+            fig1.savefig(os.path.join(filepath, 'jpg_files', sitename + '_transect_locations.jpg'), dpi=200)
+            plt.title('Transect coordinates saved as ' + sitename + '_transects.geojson')
+            plt.draw()
+            # wait 2 seconds for user to visualise the transects that are saved
+            ginput(n=1, timeout=2, show_clicks=True)
+            plt.close(fig1)
+            # break the loop
+            break
+        
+        # add selectect points to the transect dict
+        counter = counter + 1
+        transect = np.array([pts[0], pts[1]])
+        
+        # alternative of making the transect the origin, orientation and length
+#        temp = np.array(pts[1]) - np.array(origin)
+#        phi = np.arctan2(temp[1], temp[0])
+#        orientation = -(phi*180/np.pi - 90)
+#        length = np.linalg.norm(temp)
+#        transect = create_transect(origin, orientation, length)
+        
+        transects[str(counter)] = transect
+        
+        # plot the transects on the figure
+        ax1.plot(transect[:,0], transect[:,1], 'b-', lw=2.5)
+        ax1.plot(transect[0,0], transect[0,1], 'rx', markersize=10)
+        ax1.text(transect[-1,0], transect[-1,1], str(counter), size=16,
+                 bbox=dict(boxstyle="square", ec='k',fc='w'))
+        plt.draw()
+        
+    # save transects.geojson
+    gdf = SDS_tools.transects_to_gdf(transects)
+    # set projection
+    gdf.crs = {'init':'epsg:'+str(settings['output_epsg'])}
+    # save as geojson    
+    gdf.to_file(os.path.join(filepath, sitename + '_transects.geojson'), driver='GeoJSON', encoding='utf-8')
+    # print the location of the files
+    print('Transect locations saved in ' + filepath)
+        
+    return transects
+
+def compute_intersection(output, transects, settings):
+    """
+    Computes the intersection between the 2D shorelines and the shore-normal.
+    transects. It returns time-series of cross-shore distance along each transect.
+    
+    KV WRL 2018       
+
+    Arguments:
+    -----------
+    output: dict
+        contains the extracted shorelines and corresponding metadata
+    transects: dict
+        contains the X and Y coordinates of each transect
+    settings: dict with the following keys
+        'along_dist': int
+            alongshore distance considered caluclate the intersection
+              
+    Returns:    
+    -----------
+    cross_dist: dict
+        time-series of cross-shore distance along each of the transects. 
+        Not tidally corrected.        
+    """    
+    
+    # loop through shorelines and compute the median intersection    
+    intersections = np.zeros((len(output['shorelines']),len(transects)))
+    for i in range(len(output['shorelines'])):
+
+        sl = output['shorelines'][i]
+        
+        for j,key in enumerate(list(transects.keys())): 
+            
+            # compute rotation matrix
+            X0 = transects[key][0,0]
+            Y0 = transects[key][0,1]
+            temp = np.array(transects[key][-1,:]) - np.array(transects[key][0,:])
+            phi = np.arctan2(temp[1], temp[0])
+            Mrot = np.array([[np.cos(phi), np.sin(phi)],[-np.sin(phi), np.cos(phi)]])
+    
+            # calculate point to line distance between shoreline points and the transect
+            p1 = np.array([X0,Y0])
+            p2 = transects[key][-1,:]
+            d_line = np.abs(np.cross(p2-p1,sl-p1)/np.linalg.norm(p2-p1))
+            # calculate the distance between shoreline points and the origin of the transect
+            d_origin = np.array([np.linalg.norm(sl[k,:] - p1) for k in range(len(sl))])
+            # find the shoreline points that are close to the transects and to the origin
+            # the distance to the origin is hard-coded here to 1 km 
+            idx_dist = np.logical_and(d_line <= settings['along_dist'], d_origin <= 1000)
+            # find the shoreline points that are in the direction of the transect (within 90 degrees)
+            temp_sl = sl - np.array(transects[key][0,:])
+            phi_sl = np.array([np.arctan2(temp_sl[k,1], temp_sl[k,0]) for k in range(len(temp_sl))])
+            diff_angle = (phi - phi_sl)
+            idx_angle = np.abs(diff_angle) < np.pi/2
+            # combine the transects that are close in distance and close in orientation
+            idx_close = np.where(np.logical_and(idx_dist,idx_angle))[0]     
+            
+            # in case there are no shoreline points close to the transect 
+            if len(idx_close) == 0:
+                intersections[i,j] = np.nan
+            else:
+                # change of base to shore-normal coordinate system
+                xy_close = np.array([sl[idx_close,0],sl[idx_close,1]]) - np.tile(np.array([[X0],
+                                   [Y0]]), (1,len(sl[idx_close])))
+                xy_rot = np.matmul(Mrot, xy_close)
+                # compute the median of the intersections along the transect
+                intersections[i,j] = np.nanmedian(xy_rot[0,:])
+    
+    # fill the a dictionnary
+    cross_dist = dict([])
+    for j,key in enumerate(list(transects.keys())): 
+        cross_dist[key] = intersections[:,j]   
+    
+    # save a .csv file for Excel users
+    out_dict = dict([])
+    out_dict['dates'] = output['dates']
+    for key in transects.keys():
+        out_dict['Transect '+ key] = cross_dist[key]
+    df = pd.DataFrame(out_dict)
+    fn = os.path.join(settings['inputs']['filepath'],settings['inputs']['sitename'],
+                      'transect_time_series.csv')
+    df.to_csv(fn, sep=',')
+    print('Time-series of the shoreline change along the transects saved as:\n%s'%fn)
+    
+    return cross_dist

--- a/notebooks/coastsat/gdal_merge.py
+++ b/notebooks/coastsat/gdal_merge.py
@@ -1,0 +1,540 @@
+#!/usr/bin/env python
+###############################################################################
+# $Id$
+#
+# Project:  InSAR Peppers
+# Purpose:  Module to extract data from many rasters into one output.
+# Author:   Frank Warmerdam, warmerdam@pobox.com
+#
+###############################################################################
+# Copyright (c) 2000, Atlantis Scientific Inc. (www.atlsci.com)
+# Copyright (c) 2009-2011, Even Rouault <even dot rouault at mines-paris dot org>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public
+# License along with this library; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 02111-1307, USA.
+###############################################################################
+# changes 29Apr2011
+# If the input image is a multi-band one, use all the channels in
+# building the stack.
+# anssi.pekkarinen@fao.org
+
+import math
+import sys
+import time
+
+from osgeo import gdal
+
+try:
+    progress = gdal.TermProgress_nocb
+except:
+    progress = gdal.TermProgress
+
+__version__ = '$id$'[5:-1]
+verbose = 0
+quiet = 0
+
+
+# =============================================================================
+def raster_copy( s_fh, s_xoff, s_yoff, s_xsize, s_ysize, s_band_n,
+                 t_fh, t_xoff, t_yoff, t_xsize, t_ysize, t_band_n,
+                 nodata=None ):
+
+    if verbose != 0:
+        print('Copy %d,%d,%d,%d to %d,%d,%d,%d.'
+              % (s_xoff, s_yoff, s_xsize, s_ysize,
+             t_xoff, t_yoff, t_xsize, t_ysize ))
+
+    if nodata is not None:
+        return raster_copy_with_nodata(
+            s_fh, s_xoff, s_yoff, s_xsize, s_ysize, s_band_n,
+            t_fh, t_xoff, t_yoff, t_xsize, t_ysize, t_band_n,
+            nodata )
+
+    s_band = s_fh.GetRasterBand( s_band_n )
+    m_band = None
+    # Works only in binary mode and doesn't take into account
+    # intermediate transparency values for compositing.
+    if s_band.GetMaskFlags() != gdal.GMF_ALL_VALID:
+        m_band = s_band.GetMaskBand()
+    elif s_band.GetColorInterpretation() == gdal.GCI_AlphaBand:
+        m_band = s_band
+    if m_band is not None:
+        return raster_copy_with_mask(
+            s_fh, s_xoff, s_yoff, s_xsize, s_ysize, s_band_n,
+            t_fh, t_xoff, t_yoff, t_xsize, t_ysize, t_band_n,
+            m_band )
+
+    s_band = s_fh.GetRasterBand( s_band_n )
+    t_band = t_fh.GetRasterBand( t_band_n )
+
+    data = s_band.ReadRaster( s_xoff, s_yoff, s_xsize, s_ysize,
+                             t_xsize, t_ysize, t_band.DataType )
+    t_band.WriteRaster( t_xoff, t_yoff, t_xsize, t_ysize,
+                        data, t_xsize, t_ysize, t_band.DataType )
+
+    return 0
+
+# =============================================================================
+def raster_copy_with_nodata( s_fh, s_xoff, s_yoff, s_xsize, s_ysize, s_band_n,
+                             t_fh, t_xoff, t_yoff, t_xsize, t_ysize, t_band_n,
+                             nodata ):
+    try:
+        import numpy as Numeric
+    except ImportError:
+        import Numeric
+
+    s_band = s_fh.GetRasterBand( s_band_n )
+    t_band = t_fh.GetRasterBand( t_band_n )
+
+    data_src = s_band.ReadAsArray( s_xoff, s_yoff, s_xsize, s_ysize,
+                                   t_xsize, t_ysize )
+    data_dst = t_band.ReadAsArray( t_xoff, t_yoff, t_xsize, t_ysize )
+
+    nodata_test = Numeric.equal(data_src,nodata)
+    to_write = Numeric.choose( nodata_test, (data_src, data_dst) )
+
+    t_band.WriteArray( to_write, t_xoff, t_yoff )
+
+    return 0
+
+# =============================================================================
+def raster_copy_with_mask( s_fh, s_xoff, s_yoff, s_xsize, s_ysize, s_band_n,
+                           t_fh, t_xoff, t_yoff, t_xsize, t_ysize, t_band_n,
+                           m_band ):
+    try:
+        import numpy as Numeric
+    except ImportError:
+        import Numeric
+
+    s_band = s_fh.GetRasterBand( s_band_n )
+    t_band = t_fh.GetRasterBand( t_band_n )
+
+    data_src = s_band.ReadAsArray( s_xoff, s_yoff, s_xsize, s_ysize,
+                                   t_xsize, t_ysize )
+    data_mask = m_band.ReadAsArray( s_xoff, s_yoff, s_xsize, s_ysize,
+                                    t_xsize, t_ysize )
+    data_dst = t_band.ReadAsArray( t_xoff, t_yoff, t_xsize, t_ysize )
+
+    mask_test = Numeric.equal(data_mask, 0)
+    to_write = Numeric.choose( mask_test, (data_src, data_dst) )
+
+    t_band.WriteArray( to_write, t_xoff, t_yoff )
+
+    return 0
+
+# =============================================================================
+def names_to_fileinfos( names ):
+    """
+    Translate a list of GDAL filenames, into file_info objects.
+
+    names -- list of valid GDAL dataset names.
+
+    Returns a list of file_info objects.  There may be less file_info objects
+    than names if some of the names could not be opened as GDAL files.
+    """
+
+    file_infos = []
+    for name in names:
+        fi = file_info()
+        if fi.init_from_name( name ) == 1:
+            file_infos.append( fi )
+
+    return file_infos
+
+# *****************************************************************************
+class file_info:
+    """A class holding information about a GDAL file."""
+
+    def init_from_name(self, filename):
+        """
+        Initialize file_info from filename
+
+        filename -- Name of file to read.
+
+        Returns 1 on success or 0 if the file can't be opened.
+        """
+        fh = gdal.Open( filename )
+        if fh is None:
+            return 0
+
+        self.filename = filename
+        self.bands = fh.RasterCount
+        self.xsize = fh.RasterXSize
+        self.ysize = fh.RasterYSize
+        self.band_type = fh.GetRasterBand(1).DataType
+        self.projection = fh.GetProjection()
+        self.geotransform = fh.GetGeoTransform()
+        self.ulx = self.geotransform[0]
+        self.uly = self.geotransform[3]
+        self.lrx = self.ulx + self.geotransform[1] * self.xsize
+        self.lry = self.uly + self.geotransform[5] * self.ysize
+
+        ct = fh.GetRasterBand(1).GetRasterColorTable()
+        if ct is not None:
+            self.ct = ct.Clone()
+        else:
+            self.ct = None
+
+        return 1
+
+    def report( self ):
+        print('Filename: '+ self.filename)
+        print('File Size: %dx%dx%d'
+              % (self.xsize, self.ysize, self.bands))
+        print('Pixel Size: %f x %f'
+              % (self.geotransform[1],self.geotransform[5]))
+        print('UL:(%f,%f)   LR:(%f,%f)'
+              % (self.ulx,self.uly,self.lrx,self.lry))
+
+    def copy_into( self, t_fh, s_band = 1, t_band = 1, nodata_arg=None ):
+        """
+        Copy this files image into target file.
+
+        This method will compute the overlap area of the file_info objects
+        file, and the target gdal.Dataset object, and copy the image data
+        for the common window area.  It is assumed that the files are in
+        a compatible projection ... no checking or warping is done.  However,
+        if the destination file is a different resolution, or different
+        image pixel type, the appropriate resampling and conversions will
+        be done (using normal GDAL promotion/demotion rules).
+
+        t_fh -- gdal.Dataset object for the file into which some or all
+        of this file may be copied.
+
+        Returns 1 on success (or if nothing needs to be copied), and zero one
+        failure.
+        """
+        t_geotransform = t_fh.GetGeoTransform()
+        t_ulx = t_geotransform[0]
+        t_uly = t_geotransform[3]
+        t_lrx = t_geotransform[0] + t_fh.RasterXSize * t_geotransform[1]
+        t_lry = t_geotransform[3] + t_fh.RasterYSize * t_geotransform[5]
+
+        # figure out intersection region
+        tgw_ulx = max(t_ulx,self.ulx)
+        tgw_lrx = min(t_lrx,self.lrx)
+        if t_geotransform[5] < 0:
+            tgw_uly = min(t_uly,self.uly)
+            tgw_lry = max(t_lry,self.lry)
+        else:
+            tgw_uly = max(t_uly,self.uly)
+            tgw_lry = min(t_lry,self.lry)
+
+        # do they even intersect?
+        if tgw_ulx >= tgw_lrx:
+            return 1
+        if t_geotransform[5] < 0 and tgw_uly <= tgw_lry:
+            return 1
+        if t_geotransform[5] > 0 and tgw_uly >= tgw_lry:
+            return 1
+
+        # compute target window in pixel coordinates.
+        tw_xoff = int((tgw_ulx - t_geotransform[0]) / t_geotransform[1] + 0.1)
+        tw_yoff = int((tgw_uly - t_geotransform[3]) / t_geotransform[5] + 0.1)
+        tw_xsize = int((tgw_lrx - t_geotransform[0])/t_geotransform[1] + 0.5) \
+                   - tw_xoff
+        tw_ysize = int((tgw_lry - t_geotransform[3])/t_geotransform[5] + 0.5) \
+                   - tw_yoff
+
+        if tw_xsize < 1 or tw_ysize < 1:
+            return 1
+
+        # Compute source window in pixel coordinates.
+        sw_xoff = int((tgw_ulx - self.geotransform[0]) / self.geotransform[1])
+        sw_yoff = int((tgw_uly - self.geotransform[3]) / self.geotransform[5])
+        sw_xsize = int((tgw_lrx - self.geotransform[0]) \
+                       / self.geotransform[1] + 0.5) - sw_xoff
+        sw_ysize = int((tgw_lry - self.geotransform[3]) \
+                       / self.geotransform[5] + 0.5) - sw_yoff
+
+        if sw_xsize < 1 or sw_ysize < 1:
+            return 1
+
+        # Open the source file, and copy the selected region.
+        s_fh = gdal.Open( self.filename )
+
+        return raster_copy( s_fh, sw_xoff, sw_yoff, sw_xsize, sw_ysize, s_band,
+                            t_fh, tw_xoff, tw_yoff, tw_xsize, tw_ysize, t_band,
+                            nodata_arg )
+
+
+# =============================================================================
+def Usage():
+    print('Usage: gdal_merge.py [-o out_filename] [-of out_format] [-co NAME=VALUE]*')
+    print('                     [-ps pixelsize_x pixelsize_y] [-tap] [-separate] [-q] [-v] [-pct]')
+    print('                     [-ul_lr ulx uly lrx lry] [-init "value [value...]"]')
+    print('                     [-n nodata_value] [-a_nodata output_nodata_value]')
+    print('                     [-ot datatype] [-createonly] input_files')
+    print('                     [--help-general]')
+    print('')
+
+# =============================================================================
+#
+# Program mainline.
+#
+
+def main( argv=None ):
+
+    global verbose, quiet
+    verbose = 0
+    quiet = 0
+    names = []
+    format = 'GTiff'
+    out_file = 'out.tif'
+
+    ulx = None
+    psize_x = None
+    separate = 0
+    copy_pct = 0
+    nodata = None
+    a_nodata = None
+    create_options = []
+    pre_init = []
+    band_type = None
+    createonly = 0
+    bTargetAlignedPixels = False
+    start_time = time.time()
+
+    gdal.AllRegister()
+    if argv is None:
+        argv = sys.argv
+    argv = gdal.GeneralCmdLineProcessor( argv )
+    if argv is None:
+        sys.exit( 0 )
+
+    # Parse command line arguments.
+    i = 1
+    while i < len(argv):
+        arg = argv[i]
+
+        if arg == '-o':
+            i = i + 1
+            out_file = argv[i]
+
+        elif arg == '-v':
+            verbose = 1
+
+        elif arg == '-q' or arg == '-quiet':
+            quiet = 1
+
+        elif arg == '-createonly':
+            createonly = 1
+
+        elif arg == '-separate':
+            separate = 1
+
+        elif arg == '-seperate':
+            separate = 1
+
+        elif arg == '-pct':
+            copy_pct = 1
+
+        elif arg == '-ot':
+            i = i + 1
+            band_type = gdal.GetDataTypeByName( argv[i] )
+            if band_type == gdal.GDT_Unknown:
+                print('Unknown GDAL data type: %s' % argv[i])
+                sys.exit( 1 )
+
+        elif arg == '-init':
+            i = i + 1
+            str_pre_init = argv[i].split()
+            for x in str_pre_init:
+                pre_init.append(float(x))
+
+        elif arg == '-n':
+            i = i + 1
+            nodata = float(argv[i])
+
+        elif arg == '-a_nodata':
+            i = i + 1
+            a_nodata = float(argv[i])
+
+        elif arg == '-f':
+            # for backward compatibility.
+            i = i + 1
+            format = argv[i]
+
+        elif arg == '-of':
+            i = i + 1
+            format = argv[i]
+
+        elif arg == '-co':
+            i = i + 1
+            create_options.append( argv[i] )
+
+        elif arg == '-ps':
+            psize_x = float(argv[i+1])
+            psize_y = -1 * abs(float(argv[i+2]))
+            i = i + 2
+
+        elif arg == '-tap':
+            bTargetAlignedPixels = True
+
+        elif arg == '-ul_lr':
+            ulx = float(argv[i+1])
+            uly = float(argv[i+2])
+            lrx = float(argv[i+3])
+            lry = float(argv[i+4])
+            i = i + 4
+
+        elif arg[:1] == '-':
+            print('Unrecognized command option: %s' % arg)
+            Usage()
+            sys.exit( 1 )
+
+        else:
+            names.append(arg)
+
+        i = i + 1
+
+    if len(names) == 0:
+        print('No input files selected.')
+        Usage()
+        sys.exit( 1 )
+
+    Driver = gdal.GetDriverByName(format)
+    if Driver is None:
+        print('Format driver %s not found, pick a supported driver.' % format)
+        sys.exit( 1 )
+
+    DriverMD = Driver.GetMetadata()
+    if 'DCAP_CREATE' not in DriverMD:
+        print('Format driver %s does not support creation and piecewise writing.\nPlease select a format that does, such as GTiff (the default) or HFA (Erdas Imagine).' % format)
+        sys.exit( 1 )
+
+    # Collect information on all the source files.
+    file_infos = names_to_fileinfos( names )
+
+    if ulx is None:
+        ulx = file_infos[0].ulx
+        uly = file_infos[0].uly
+        lrx = file_infos[0].lrx
+        lry = file_infos[0].lry
+
+        for fi in file_infos:
+            ulx = min(ulx, fi.ulx)
+            uly = max(uly, fi.uly)
+            lrx = max(lrx, fi.lrx)
+            lry = min(lry, fi.lry)
+
+    if psize_x is None:
+        psize_x = file_infos[0].geotransform[1]
+        psize_y = file_infos[0].geotransform[5]
+
+    if band_type is None:
+        band_type = file_infos[0].band_type
+
+    # Try opening as an existing file.
+    gdal.PushErrorHandler( 'CPLQuietErrorHandler' )
+    t_fh = gdal.Open( out_file, gdal.GA_Update )
+    gdal.PopErrorHandler()
+
+    # Create output file if it does not already exist.
+    if t_fh is None:
+
+        if bTargetAlignedPixels:
+            ulx = math.floor(ulx / psize_x) * psize_x
+            lrx = math.ceil(lrx / psize_x) * psize_x
+            lry = math.floor(lry / -psize_y) * -psize_y
+            uly = math.ceil(uly / -psize_y) * -psize_y
+
+        geotransform = [ulx, psize_x, 0, uly, 0, psize_y]
+
+        xsize = int((lrx - ulx) / geotransform[1] + 0.5)
+        ysize = int((lry - uly) / geotransform[5] + 0.5)
+
+
+        if separate != 0:
+            bands=0
+
+            for fi in file_infos:
+                bands=bands + fi.bands
+        else:
+            bands = file_infos[0].bands
+
+
+        t_fh = Driver.Create( out_file, xsize, ysize, bands,
+                              band_type, create_options )
+        if t_fh is None:
+            print('Creation failed, terminating gdal_merge.')
+            sys.exit( 1 )
+
+        t_fh.SetGeoTransform( geotransform )
+        t_fh.SetProjection( file_infos[0].projection )
+
+        if copy_pct:
+            t_fh.GetRasterBand(1).SetRasterColorTable(file_infos[0].ct)
+    else:
+        if separate != 0:
+            bands=0
+            for fi in file_infos:
+                bands=bands + fi.bands
+            if t_fh.RasterCount < bands :
+                print('Existing output file has less bands than the input files. You should delete it before. Terminating gdal_merge.')
+                sys.exit( 1 )
+        else:
+            bands = min(file_infos[0].bands,t_fh.RasterCount)
+
+    # Do we need to set nodata value ?
+    if a_nodata is not None:
+        for i in range(t_fh.RasterCount):
+            t_fh.GetRasterBand(i+1).SetNoDataValue(a_nodata)
+
+    # Do we need to pre-initialize the whole mosaic file to some value?
+    if pre_init is not None:
+        if t_fh.RasterCount <= len(pre_init):
+            for i in range(t_fh.RasterCount):
+                t_fh.GetRasterBand(i+1).Fill( pre_init[i] )
+        elif len(pre_init) == 1:
+            for i in range(t_fh.RasterCount):
+                t_fh.GetRasterBand(i+1).Fill( pre_init[0] )
+
+    # Copy data from source files into output file.
+    t_band = 1
+
+    if quiet == 0 and verbose == 0:
+        progress( 0.0 )
+    fi_processed = 0
+
+    for fi in file_infos:
+        if createonly != 0:
+            continue
+
+        if verbose != 0:
+            print("")
+            print("Processing file %5d of %5d, %6.3f%% completed in %d minutes."
+                  % (fi_processed+1,len(file_infos),
+                     fi_processed * 100.0 / len(file_infos),
+                     int(round((time.time() - start_time)/60.0)) ))
+            fi.report()
+
+        if separate == 0 :
+            for band in range(1, bands+1):
+                fi.copy_into( t_fh, band, band, nodata )
+        else:
+            for band in range(1, fi.bands+1):
+                fi.copy_into( t_fh, band, t_band, nodata )
+                t_band = t_band+1
+
+        fi_processed = fi_processed+1
+        if quiet == 0 and verbose == 0:
+            progress( fi_processed / float(len(file_infos))  )
+
+    # Force file to be closed.
+    t_fh = None
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
# Prototype 6 CoastSat  Used to Download the Generated ROIs Along a Coast
![prototype6_demo](https://user-images.githubusercontent.com/61564689/151040217-41fe4197-0f4c-4ec8-bac6-e2f6c1848864.gif)

## Description
This PR contains a jupyter notebook that can be used to generate ROIs alone a coastline vector, which the user can click to select the ROIs are the regions to be downloaded with [CoastSat](https://github.com/kvos/CoastSat).

## Related Pull Requests
#27 #28 
Both of these  PRs are necessary for prototype 6 to function properly

## Known Bugs
1.  When the user tries to erase the bounding box from the map it will show as erase from the map but not be removed from the shapes_list. 

## More Demo Footage 
1. This short gif showcases how to download the ROI after clicking them.
![prototype6_demo_1](https://user-images.githubusercontent.com/61564689/151041206-bf962dbe-5894-4f55-a0d0-ec9ca2fadf84.gif)

